### PR TITLE
Handle storing environment variables

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -453,7 +453,6 @@
         </codeStyleSettings>
       </value>
     </option>
-    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Spring Data" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Spring Deployer" />
   </component>
 </project>

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -21,6 +21,9 @@ import static java.util.stream.Stream.concat;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,12 +31,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationRequest;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.applications.ApplicationDetail;
 import org.cloudfoundry.operations.applications.DeleteApplicationRequest;
 import org.cloudfoundry.operations.applications.GetApplicationRequest;
 import org.cloudfoundry.operations.applications.PushApplicationRequest;
-import org.cloudfoundry.operations.applications.SetEnvironmentVariableApplicationRequest;
 import org.cloudfoundry.operations.applications.StartApplicationRequest;
 import org.cloudfoundry.operations.services.BindServiceInstanceRequest;
 import reactor.core.publisher.Flux;
@@ -46,7 +50,7 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 
 /**
  * A deployer that targets Cloud Foundry using the public API.
- * 
+ *
  * @author Eric Bottard
  * @author Greg Turnquist
  */
@@ -63,11 +67,15 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 
 	private final CloudFoundryOperations operations;
 
+	private final CloudFoundryClient client;
+
 	private static final Log logger = LogFactory.getLog(CloudFoundryAppDeployer.class);
 
-	public CloudFoundryAppDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations) {
+	public CloudFoundryAppDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations,
+								   CloudFoundryClient client) {
 		this.properties = properties;
 		this.operations = operations;
+		this.client = client;
 	}
 
 	@Override
@@ -87,13 +95,19 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 
 	Mono<Void> asyncDeploy(AppDeploymentRequest request) {
 		String name = deploymentId(request);
-		final String argsAsJson;
+
+		Map<String, String> envVariables = new HashMap<>();
+
 		try {
-			argsAsJson = new ObjectMapper().writeValueAsString(request.getDefinition().getProperties());
-		}
-		catch (JsonProcessingException e) {
+			envVariables.put("SPRING_APPLICATION_JSON",
+				new ObjectMapper().writeValueAsString(
+					Optional.ofNullable(request.getDefinition().getProperties())
+							.orElse(Collections.emptyMap())));
+			envVariables.putAll(request.getEnvironmentProperties());
+		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);
 		}
+
 		try {
 			return operations.applications()
 				.push(PushApplicationRequest.builder()
@@ -108,14 +122,15 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 					.build())
 				.doOnSuccess(v -> logger.info(String.format("Done uploading bits for %s", name)))
 				.doOnError(e -> logger.error(String.format("Error creating app %s", name), e))
-				.after(() -> operations.applications().setEnvironmentVariable(
-					SetEnvironmentVariableApplicationRequest.builder()
-						.name(name)
-						.variableName("SPRING_APPLICATION_JSON")
-						.variableValue(argsAsJson)
-						.build())
-					.doOnSuccess(v -> logger.debug(String.format("Setting env for app %s as %s", name, argsAsJson)))
-					.doOnError(e -> logger.error(String.format("Error setting environment for app %s", name), e))
+				// TODO: Replace the following clause with an -operations API call
+				.after(() -> getApplicationId(name)
+					.then(applicationId -> client.applicationsV2()
+						.update(UpdateApplicationRequest.builder()
+							.applicationId(applicationId)
+							.environmentJsons(envVariables)
+							.build()))
+					.doOnSuccess(v -> logger.debug(String.format("Setting individual env variables to %s for app %s", envVariables, name)))
+					.doOnError(e -> logger.error(String.format("Unable to set individual env variables for app %s", name)))
 				)
 				.after(() -> servicesToBind(request)
 					.flatMap(service -> operations.services()
@@ -137,6 +152,20 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 		} catch (IOException e) {
 			return Mono.error(e);
 		}
+	}
+
+	private static boolean matchesSpringAppJsonPattern(Map.Entry<String, String> entry, List<String> patterns) {
+		return patterns.stream()
+			.filter(pattern -> entry.getKey().startsWith(pattern))
+			.findAny()
+			.map(match -> true)
+			.orElse(false);
+	}
+
+	private static Optional<String> findSpringAppJsonPattern(Map.Entry<String, String> entry, List<String> patterns) {
+		return patterns.stream()
+			.filter(pattern -> entry.getKey().startsWith(pattern))
+			.findAny();
 	}
 
 	@Override
@@ -173,14 +202,18 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 	}
 
 
-	private Flux<Map.Entry<String, String>> environmenVariables(AppDeploymentRequest request) {
-		return Flux.fromStream(request.getDefinition().getProperties().entrySet().stream());
-	}
-
 	private String deploymentId(AppDeploymentRequest request) {
 		return Optional.ofNullable(request.getEnvironmentProperties().get(GROUP_PROPERTY_KEY))
-						.map(groupName -> String.format("%s-", groupName))
-						.orElse("") + request.getDefinition().getName();
+				.map(groupName -> String.format("%s-", groupName))
+				.orElse("") + request.getDefinition().getName();
+	}
+
+	private Mono<String> getApplicationId(String name) {
+		return operations.applications()
+			.get(GetApplicationRequest.builder()
+				.name(name)
+				.build())
+			.map(applicationDetail -> applicationDetail.getId());
 	}
 
 	private Flux<String> servicesToBind(AppDeploymentRequest request) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -66,8 +66,8 @@ public class CloudFoundryDeployerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(AppDeployer.class)
-	public AppDeployer appDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations) {
-		return new CloudFoundryAppDeployer(properties, operations);
+	public AppDeployer appDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations, CloudFoundryClient client) {
+		return new CloudFoundryAppDeployer(properties, operations, client);
 	}
 
 	@Bean

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerProperties.java
@@ -194,4 +194,5 @@ public class CloudFoundryDeployerProperties {
 	public void setInstances(int instances) {
 		this.instances = instances;
 	}
+
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -18,15 +18,28 @@ package org.springframework.cloud.deployer.spi.cloudfoundry;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.applications.ApplicationsV2;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationRequest;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationResponse;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.applications.ApplicationDetail;
 import org.cloudfoundry.operations.applications.Applications;
+import org.cloudfoundry.util.test.TestSubscriber;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
@@ -35,51 +48,140 @@ import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 
 /**
+ * Unit tests for the {@link CloudFoundryAppDeployer}.
+ *
  * @author Greg Turnquist
  */
 public class CloudFoundryAppDeployerTests {
 
-    CloudFoundryOperations operations;
+	CloudFoundryOperations operations;
 
-    Applications applications;
+	CloudFoundryClient client;
 
-    CloudFoundryAppDeployer deployer;
+	Applications applications;
 
-    @Before
-    public void setUp() {
+	ApplicationsV2 applicationsV2;
 
-        operations = mock(CloudFoundryOperations.class);
-        applications = mock(Applications.class);
-        deployer = new CloudFoundryAppDeployer(new CloudFoundryDeployerProperties(), operations);
-    }
+	CloudFoundryAppDeployer deployer;
 
-    @Test
-    public void shouldSwitchToSimpleDeploymentIdWhenGroupIsLeftOut() {
+	@Before
+	public void setUp() {
 
-        when(operations.applications()).thenReturn(applications);
-        when(applications.get(any())).thenReturn(Mono.just(ApplicationDetail.builder().build()));
+		operations = mock(CloudFoundryOperations.class);
+		client = mock(CloudFoundryClient.class);
+		applications = mock(Applications.class);
+		applicationsV2 = mock(ApplicationsV2.class);
+		deployer = new CloudFoundryAppDeployer(new CloudFoundryDeployerProperties(), operations, client);
+	}
 
-        String deploymentId = deployer.deploy(new AppDeploymentRequest(
-            new AppDefinition("test", Collections.emptyMap()),
-            new FileSystemResource("")));
+	@Test
+	public void shouldSwitchToSimpleDeploymentIdWhenGroupIsLeftOut() {
 
-        assertThat(deploymentId, equalTo("test"));
-    }
+		// given
+		given(operations.applications()).willReturn(applications);
+		given(applications.get(any())).willReturn(Mono.just(ApplicationDetail.builder().build()));
 
-    @Test
-    public void shouldNamespaceTheDeploymentIdWhenAGroupIsUsed() {
+		// when
+		String deploymentId = deployer.deploy(new AppDeploymentRequest(
+				new AppDefinition("test", Collections.emptyMap()),
+				new FileSystemResource("")));
 
-        when(operations.applications()).thenReturn(applications);
-        when(applications.get(any())).thenReturn(Mono.just(ApplicationDetail.builder().build()));
+		// then
+		assertThat(deploymentId, equalTo("test"));
+	}
 
-        String deploymentId = deployer.deploy(new AppDeploymentRequest(
-            new AppDefinition("test", Collections.emptyMap()),
-            new FileSystemResource(""),
-            Collections.singletonMap(AppDeployer.GROUP_PROPERTY_KEY, "prefix")));
+	@Test
+	public void shouldNamespaceTheDeploymentIdWhenAGroupIsUsed() {
 
-        assertThat(deploymentId, equalTo("prefix-test"));
-    }
+		// given
+		given(operations.applications()).willReturn(applications);
+		given(applications.get(any())).willReturn(Mono.just(ApplicationDetail.builder().build()));
+
+		// when
+		String deploymentId = deployer.deploy(new AppDeploymentRequest(
+				new AppDefinition("test", Collections.emptyMap()),
+				new FileSystemResource(""),
+				Collections.singletonMap(AppDeployer.GROUP_PROPERTY_KEY, "prefix")));
+
+		// then
+		assertThat(deploymentId, equalTo("prefix-test"));
+	}
+
+	@Test
+	public void shouldMoveSomeIntoSpringAppJson() throws InterruptedException, JsonProcessingException {
+
+		// given
+		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+
+		// Define the env variables for the app
+		Map<String, String> appDefinitionProperties = new HashMap<>();
+
+		final String fooKey = "spring.cloud.foo";
+		final String fooVal = "this should end up in SPRING_APPLICATION_JSON";
+
+		final String barKey = "spring.cloud.bar";
+		final String barVal = "this should too";
+
+		final String varKey = "spring.other.var";
+		final String varVal = "this should NOT end up there.";
+
+		appDefinitionProperties.put(fooKey, fooVal);
+		appDefinitionProperties.put(barKey, barVal);
+		appDefinitionProperties.put(varKey, varVal);
+
+		deployer = new CloudFoundryAppDeployer(properties, operations, client);
+
+		given(operations.applications()).willReturn(applications);
+
+		given(applications.get(any())).willReturn(Mono.just(ApplicationDetail.builder()
+				.id("abc123")
+				.build()));
+		given(applications.push(any())).willReturn(Mono.empty());
+		given(applications.start(any())).willReturn(Mono.empty());
+
+		given(client.applicationsV2()).willReturn(applicationsV2);
+
+		given(applicationsV2.update(any())).willReturn(Mono.just(UpdateApplicationResponse.builder()
+			.build()));
+
+		// when
+		final TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+
+		deployer.asyncDeploy(new AppDeploymentRequest(
+				new AppDefinition("test", Collections.singletonMap("some.key", "someValue")),
+				mock(Resource.class),
+				appDefinitionProperties))
+			.subscribe(testSubscriber);
+
+		testSubscriber.verify(Duration.ofSeconds(10L));
+
+		// then
+		then(operations).should(times(3)).applications();
+		verifyNoMoreInteractions(operations);
+
+		then(applications).should().push(any());
+		then(applications).should().get(any());
+		then(applications).should().start(any());
+		verifyNoMoreInteractions(applications);
+
+		then(client).should().applicationsV2();
+		verifyNoMoreInteractions(client);
+
+		then(applicationsV2).should().update(UpdateApplicationRequest.builder()
+				.applicationId("abc123")
+				.environmentJsons(new HashMap<String, String>() {{
+					put("SPRING_APPLICATION_JSON",
+						new ObjectMapper().writeValueAsString(
+							Collections.singletonMap("some.key", "someValue")));
+					put(fooKey, fooVal);
+					put(barKey, barVal);
+					put(varKey, varVal);
+				}})
+				.build());
+		verifyNoMoreInteractions(applicationsV2);
+	}
 
 }


### PR DESCRIPTION
Using a configurable prefix (defaulted to 'spring_application_json.') split up environment properties meant for SPRING_APPLICATION_JSON vs. single environment properties.

Resolves #12