### PR TITLE
Allow overriding buildpack, and switching to direct env variables

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.deployer.spi.cloudfoundry;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +38,10 @@ public class CloudFoundryDeployerProperties {
 	public static final String DISK_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.disk";
 
 	public static final String SERVICES_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.services";
+
+	public static final String BUILDPACK_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.buildpack";
+
+	public static final String USE_SPRING_APPLICATION_JSON_KEY = "spring.cloud.deployer.cloudfoundry.use-spring-application-json";
 
 	/**
 	 * The names of services to bind to all applications deployed as a module.
@@ -114,6 +119,11 @@ public class CloudFoundryDeployerProperties {
 	 * Timeout for blocking task launches
 	 */
 	private long taskTimeout = 30L;
+
+	/**
+	 * Flag to indicate whether application properties are fed into SPRING_APPLICATION_JSON or ENVIRONMENT VARIABLES.
+	 */
+	private boolean useSpringApplicationJson = true;
 
 	/**
 	 * String to use as prefix for name of deployed app.  Defaults to spring.application.name
@@ -240,4 +250,14 @@ public class CloudFoundryDeployerProperties {
 	public void setTaskTimeout(long taskTimeout) {
 		this.taskTimeout = taskTimeout;
 	}
+
+	public boolean isUseSpringApplicationJson() {
+		return useSpringApplicationJson;
+	}
+
+	public void setUseSpringApplicationJson(boolean useSpringApplicationJson) {
+		this.useSpringApplicationJson = useSpringApplicationJson;
+	}
+
+
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -143,10 +143,10 @@ public class CloudFoundryAppDeployerTests {
 		Map<String, String> deploymentProperties = new HashMap<>();
 
 		final String fooKey = "spring.cloud.foo";
-		final String fooVal = "this should end up in SPRING_APPLICATION_JSON";
+		final String fooVal = "this should NOT end up in SPRING_APPLICATION_JSON";
 
 		final String barKey = "another.cloud.bar";
-		final String barVal = "this should too";
+		final String barVal = "neither should";
 
 		deploymentProperties.put(fooKey, fooVal);
 		deploymentProperties.put(barKey, barVal);
@@ -194,6 +194,74 @@ public class CloudFoundryAppDeployerTests {
 					put("SPRING_APPLICATION_JSON",
 							new ObjectMapper().writeValueAsString(
 									Collections.singletonMap("some.key", "someValue")));
+					// Note that fooKey and barKey are not expected to be in the environment as they are
+					// deployment properties
+				}})
+				.build());
+		verifyNoMoreInteractions(applicationsV2);
+	}
+
+	@Test
+	public void applyAppPropertiesIndividually() throws InterruptedException, IOException {
+
+		// given
+		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+
+		// Define the deployment properties for the app
+		Map<String, String> deploymentProperties = new HashMap<>();
+
+		final String fooKey = "spring.cloud.foo";
+		final String fooVal = "this should NOT end up in SPRING_APPLICATION_JSON";
+
+		final String barKey = "another.cloud.bar";
+		final String barVal = "neither should this";
+
+		deploymentProperties.put(fooKey, fooVal);
+		deploymentProperties.put(barKey, barVal);
+
+		deployer = new CloudFoundryAppDeployer(properties, operations, client, deploymentCustomizer);
+
+		given(operations.applications()).willReturn(applications);
+
+		mockGetApplication("test", "RUNNING");
+		given(applications.push(any())).willReturn(Mono.empty());
+		given(applications.start(any())).willReturn(Mono.empty());
+
+		given(client.applicationsV2()).willReturn(applicationsV2);
+
+		given(applicationsV2.update(any())).willReturn(Mono.just(UpdateApplicationResponse.builder()
+				.build()));
+
+		// when
+		final TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+		FileSystemResource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		deploymentProperties.put(CloudFoundryDeployerProperties.USE_SPRING_APPLICATION_JSON_KEY, "false");
+
+		deployer.asyncDeploy(new AppDeploymentRequest(
+				new AppDefinition("test", Collections.singletonMap("some.key", "someValue")),
+				resource,
+				deploymentProperties))
+				.subscribe(testSubscriber);
+
+		testSubscriber.verify(Duration.ofSeconds(10L));
+
+		// then
+		then(operations).should(times(3)).applications();
+		verifyNoMoreInteractions(operations);
+
+		then(applications).should().push(any());
+		then(applications).should().get(any());
+		then(applications).should().start(any());
+		verifyNoMoreInteractions(applications);
+
+		then(client).should().applicationsV2();
+		verifyNoMoreInteractions(client);
+
+		then(applicationsV2).should().update(UpdateApplicationRequest.builder()
+				.applicationId("abc123")
+				.environmentJsons(new HashMap<String, String>() {{
+					put("some.key", "someValue");
 					// Note that fooKey and barKey are not expected to be in the environment as they are
 					// deployment properties
 				}})


### PR DESCRIPTION
* Override buildpack on a per-request basis with new deployment property
* Provide option to use direct env variables instead of SPRING_APPLICATION_JSON for request env variables.

Resolves #36