### PR TITLE
Split ConfigurationProperties in two: auth and deployment conf.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -55,7 +55,7 @@ import static org.springframework.util.StringUtils.commaDelimitedListToSet;
  */
 public class CloudFoundryAppDeployer implements AppDeployer {
 
-	private final CloudFoundryDeployerProperties properties;
+	private final CloudFoundryConnectionProperties properties;
 
 	private final CloudFoundryOperations operations;
 
@@ -65,7 +65,7 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 
 	private static final Log logger = LogFactory.getLog(CloudFoundryAppDeployer.class);
 
-	public CloudFoundryAppDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations,
+	public CloudFoundryAppDeployer(CloudFoundryConnectionProperties properties, CloudFoundryOperations operations,
 								   CloudFoundryClient client, AppNameGenerator appDeploymentCustomizer) {
 		this.properties = properties;
 		this.operations = operations;
@@ -183,7 +183,7 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 			.map(AppStatus.Builder::build);
 	}
 
-	public CloudFoundryDeployerProperties getProperties() {
+	public CloudFoundryConnectionProperties getProperties() {
 		return properties;
 	}
 
@@ -206,12 +206,12 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 		return Flux.fromStream(
 			concat(
 				properties.getServices().stream(),
-				commaDelimitedListToSet(request.getDeploymentProperties().get(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY)).stream()));
+				commaDelimitedListToSet(request.getDeploymentProperties().get(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY)).stream()));
 	}
 
 	private int memory(AppDeploymentRequest request) {
 		return parseInt(
-			request.getDeploymentProperties().getOrDefault(CloudFoundryDeployerProperties.MEMORY_PROPERTY_KEY, valueOf(properties.getMemory())));
+			request.getDeploymentProperties().getOrDefault(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, valueOf(properties.getMemory())));
 	}
 
 	private int instances(AppDeploymentRequest request) {
@@ -221,7 +221,7 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 
 	private int diskQuota(AppDeploymentRequest request) {
 		return parseInt(
-			request.getDeploymentProperties().getOrDefault(CloudFoundryDeployerProperties.DISK_PROPERTY_KEY, valueOf(properties.getDisk())));
+			request.getDeploymentProperties().getOrDefault(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, valueOf(properties.getDisk())));
 	}
 
 	private Mono<AppStatus.Builder> createAppStatusBuilder(String id, ApplicationDetail ad) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGenerator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGenerator.java
@@ -43,13 +43,13 @@ public class CloudFoundryAppNameGenerator implements AppNameGenerator, Initializ
 
 	private String prefixToUse = "";
 
-	private final CloudFoundryDeployerProperties properties;
+	private final CloudFoundryConnectionProperties properties;
 
 	private final WordListRandomWords wordListRandomWords;
 
-	public CloudFoundryAppNameGenerator(CloudFoundryDeployerProperties cloudFoundryDeployerProperties,
+	public CloudFoundryAppNameGenerator(CloudFoundryConnectionProperties cloudFoundryConnectionProperties,
 										WordListRandomWords wordListRandomWords) {
-		this.properties = cloudFoundryDeployerProperties;
+		this.properties = cloudFoundryConnectionProperties;
 		this.wordListRandomWords = wordListRandomWords;
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGenerator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGenerator.java
@@ -43,13 +43,13 @@ public class CloudFoundryAppNameGenerator implements AppNameGenerator, Initializ
 
 	private String prefixToUse = "";
 
-	private final CloudFoundryConnectionProperties properties;
+	private final CloudFoundryDeploymentProperties properties;
 
 	private final WordListRandomWords wordListRandomWords;
 
-	public CloudFoundryAppNameGenerator(CloudFoundryConnectionProperties cloudFoundryConnectionProperties,
+	public CloudFoundryAppNameGenerator(CloudFoundryDeploymentProperties cloudFoundryDeploymentProperties,
 										WordListRandomWords wordListRandomWords) {
-		this.properties = cloudFoundryConnectionProperties;
+		this.properties = cloudFoundryDeploymentProperties;
 		this.wordListRandomWords = wordListRandomWords;
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -16,11 +16,9 @@
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
 import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -29,20 +27,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Eric Bottard
  * @author Greg Turnquist
  */
-@ConfigurationProperties(prefix = "spring.cloud.deployer.cloudfoundry")
+@ConfigurationProperties(prefix = CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES)
 public class CloudFoundryConnectionProperties {
 
-	public static final String MEMORY_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.memory";
-
-	public static final String DISK_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.disk";
-
-	public static final String SERVICES_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.services";
-
 	/**
-	 * The names of services to bind to all applications deployed as a module.
-	 * This should typically contain a service capable of playing the role of a binding transport.
+	 * Top level prefix for Cloud Foundry related configuration properties.
 	 */
-	private Set<String> services = new HashSet<>();
+	public static final String CLOUDFOUNDRY_PROPERTIES = "spring.cloud.deployer.cloudfoundry";
 
 	/**
 	 * The domain to use when mapping routes for applications.
@@ -84,50 +75,6 @@ public class CloudFoundryConnectionProperties {
 	 * Allow operation using self-signed certificates.
 	 */
 	private boolean skipSslValidation = false;
-
-	/**
-	 * The buildpack to use for deploying the application.
-	 */
-	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git";
-
-	/**
-	 * The amount of memory (MB) to allocate, if not overridden per-module.
-	 */
-	private int memory = 1024;
-
-	/**
-	 * The amount of disk space (MB) to allocate, if not overridden per-module.
-	 */
-	private int disk = 1024;
-
-	/**
-	 * The number of instances to run.
-	 */
-	private int instances = 1;
-
-	/**
-	 * Flag to enable prefixing the app name with a random prefix
-	 */
-	private boolean enableRandomAppNamePrefix = true;
-
-	/**
-	 * Timeout for blocking task launches
-	 */
-	private long taskTimeout = 30L;
-
-	/**
-	 * String to use as prefix for name of deployed app.  Defaults to spring.application.name
-	 */
-	@Value("${spring.application.name:}")
-	private String appNamePrefix;
-
-	public Set<String> getServices() {
-		return services;
-	}
-
-	public void setServices(Set<String> services) {
-		this.services = services;
-	}
 
 	public String getDomain() {
 		return domain;
@@ -185,59 +132,4 @@ public class CloudFoundryConnectionProperties {
 		this.skipSslValidation = skipSslValidation;
 	}
 
-	public String getBuildpack() {
-		return buildpack;
-	}
-
-	public void setBuildpack(String buildpack) {
-		this.buildpack = buildpack;
-	}
-
-	public int getMemory() {
-		return memory;
-	}
-
-	public void setMemory(int memory) {
-		this.memory = memory;
-	}
-
-	public int getDisk() {
-		return disk;
-	}
-
-	public void setDisk(int disk) {
-		this.disk = disk;
-	}
-
-	public int getInstances() {
-		return instances;
-	}
-
-	public void setInstances(int instances) {
-		this.instances = instances;
-	}
-
-	public boolean isEnableRandomAppNamePrefix() {
-		return enableRandomAppNamePrefix;
-	}
-
-	public void setEnableRandomAppNamePrefix(boolean enableRandomAppNamePrefix) {
-		this.enableRandomAppNamePrefix = enableRandomAppNamePrefix;
-	}
-
-	public String getAppNamePrefix() {
-		return appNamePrefix;
-	}
-
-	public void setAppNamePrefix(String appNamePrefix) {
-		this.appNamePrefix = appNamePrefix;
-	}
-
-	public long getTaskTimeout() {
-		return taskTimeout;
-	}
-
-	public void setTaskTimeout(long taskTimeout) {
-		this.taskTimeout = taskTimeout;
-	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Greg Turnquist
  */
 @ConfigurationProperties(prefix = "spring.cloud.deployer.cloudfoundry")
-public class CloudFoundryDeployerProperties {
+public class CloudFoundryConnectionProperties {
 
 	public static final String MEMORY_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.memory";
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -42,13 +42,13 @@ import org.springframework.core.Ordered;
  * @author Eric Bottard
  */
 @Configuration
-@EnableConfigurationProperties(CloudFoundryDeployerProperties.class)
+@EnableConfigurationProperties(CloudFoundryConnectionProperties.class)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 public class CloudFoundryDeployerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConnectionContext connectionContext(CloudFoundryDeployerProperties properties) {
+	public ConnectionContext connectionContext(CloudFoundryConnectionProperties properties) {
 		return DefaultConnectionContext.builder()
 				.apiHost(properties.getUrl().getHost())
 				.skipSslValidation(properties.isSkipSslValidation())
@@ -57,7 +57,7 @@ public class CloudFoundryDeployerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TokenProvider tokenProvider(CloudFoundryDeployerProperties properties) {
+	public TokenProvider tokenProvider(CloudFoundryConnectionProperties properties) {
 		return PasswordGrantTokenProvider.builder()
 				.username(properties.getUsername())
 				.password(properties.getPassword())
@@ -78,7 +78,7 @@ public class CloudFoundryDeployerAutoConfiguration {
 	public CloudFoundryOperations cloudFoundryOperations(CloudFoundryClient cloudFoundryClient,
 														 ConnectionContext connectionContext,
 														 TokenProvider tokenProvider,
-														 CloudFoundryDeployerProperties properties) {
+														 CloudFoundryConnectionProperties properties) {
 		ReactorDopplerClient dopplerClient = ReactorDopplerClient.builder()
 				.connectionContext(connectionContext)
 				.tokenProvider(tokenProvider)
@@ -101,20 +101,20 @@ public class CloudFoundryDeployerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(AppDeployer.class)
-	public AppDeployer appDeployer(CloudFoundryDeployerProperties properties, CloudFoundryOperations operations, CloudFoundryClient client,
+	public AppDeployer appDeployer(CloudFoundryConnectionProperties properties, CloudFoundryOperations operations, CloudFoundryClient client,
 								   AppNameGenerator appDeploymentCustomizer) {
 		return new CloudFoundryAppDeployer(properties, operations, client, appDeploymentCustomizer);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(AppNameGenerator.class)
-	public AppNameGenerator appDeploymentCustomizer(CloudFoundryDeployerProperties properties) {
+	public AppNameGenerator appDeploymentCustomizer(CloudFoundryConnectionProperties properties) {
 		return new CloudFoundryAppNameGenerator(properties, new WordListRandomWords());
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(TaskLauncher.class)
-	public TaskLauncher taskLauncher(CloudFoundryClient client, CloudFoundryDeployerProperties properties, CloudFoundryOperations operations) {
+	public TaskLauncher taskLauncher(CloudFoundryClient client, CloudFoundryConnectionProperties properties, CloudFoundryOperations operations) {
 		return new CloudFoundryTaskLauncher(client, operations, properties);
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -28,14 +30,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Eric Bottard
  * @author Greg Turnquist
  */
-@ConfigurationProperties(prefix = "spring.cloud.deployer.cloudfoundry")
 public class CloudFoundryDeploymentProperties {
 
-	public static final String MEMORY_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.memory";
+	public static final String MEMORY_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".memory";
 
-	public static final String DISK_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.disk";
+	public static final String DISK_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".disk";
 
-	public static final String SERVICES_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.services";
+	public static final String SERVICES_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".services";
 
 	/**
 	 * The names of services to bind to all applications deployed as a module.

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Holds configuration properties for specifying what resources and services an app deployed to a Cloud Foundry runtime
+ * will get.
+ *
+ * @author Eric Bottard
+ * @author Greg Turnquist
+ */
+@ConfigurationProperties(prefix = "spring.cloud.deployer.cloudfoundry")
+public class CloudFoundryDeploymentProperties {
+
+	public static final String MEMORY_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.memory";
+
+	public static final String DISK_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.disk";
+
+	public static final String SERVICES_PROPERTY_KEY = "spring.cloud.deployer.cloudfoundry.services";
+
+	/**
+	 * The names of services to bind to all applications deployed as a module.
+	 * This should typically contain a service capable of playing the role of a binding transport.
+	 */
+	private Set<String> services = new HashSet<>();
+
+	/**
+	 * The buildpack to use for deploying the application.
+	 */
+	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git";
+
+	/**
+	 * The amount of memory (MB) to allocate, if not overridden per-module.
+	 */
+	private int memory = 1024;
+
+	/**
+	 * The amount of disk space (MB) to allocate, if not overridden per-module.
+	 */
+	private int disk = 1024;
+
+	/**
+	 * The number of instances to run.
+	 */
+	private int instances = 1;
+
+	/**
+	 * Flag to enable prefixing the app name with a random prefix
+	 */
+	private boolean enableRandomAppNamePrefix = true;
+
+	/**
+	 * Timeout for blocking task launches
+	 */
+	private long taskTimeout = 30L;
+
+	/**
+	 * String to use as prefix for name of deployed app.  Defaults to spring.application.name
+	 */
+	@Value("${spring.application.name:}")
+	private String appNamePrefix;
+
+	public Set<String> getServices() {
+		return services;
+	}
+
+	public void setServices(Set<String> services) {
+		this.services = services;
+	}
+
+	public String getBuildpack() {
+		return buildpack;
+	}
+
+	public void setBuildpack(String buildpack) {
+		this.buildpack = buildpack;
+	}
+
+	public int getMemory() {
+		return memory;
+	}
+
+	public void setMemory(int memory) {
+		this.memory = memory;
+	}
+
+	public int getDisk() {
+		return disk;
+	}
+
+	public void setDisk(int disk) {
+		this.disk = disk;
+	}
+
+	public int getInstances() {
+		return instances;
+	}
+
+	public void setInstances(int instances) {
+		this.instances = instances;
+	}
+
+	public boolean isEnableRandomAppNamePrefix() {
+		return enableRandomAppNamePrefix;
+	}
+
+	public void setEnableRandomAppNamePrefix(boolean enableRandomAppNamePrefix) {
+		this.enableRandomAppNamePrefix = enableRandomAppNamePrefix;
+	}
+
+	public String getAppNamePrefix() {
+		return appNamePrefix;
+	}
+
+	public void setAppNamePrefix(String appNamePrefix) {
+		this.appNamePrefix = appNamePrefix;
+	}
+
+	public long getTaskTimeout() {
+		return taskTimeout;
+	}
+
+	public void setTaskTimeout(long taskTimeout) {
+		this.taskTimeout = taskTimeout;
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
@@ -98,11 +98,11 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 
     private final CloudFoundryOperations operations;
 
-    private final CloudFoundryDeployerProperties properties;
+    private final CloudFoundryConnectionProperties properties;
 
     private long timeout = 30L;
 
-    public CloudFoundryTaskLauncher(CloudFoundryClient client, CloudFoundryOperations operations, CloudFoundryDeployerProperties properties) {
+    public CloudFoundryTaskLauncher(CloudFoundryClient client, CloudFoundryOperations operations, CloudFoundryConnectionProperties properties) {
         this.client = client;
         this.operations = operations;
         this.properties = properties;
@@ -438,7 +438,7 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
     private Set<String> servicesToBind(AppDeploymentRequest request) {
         Set<String> services = new HashSet<>();
         services.addAll(this.properties.getServices());
-        services.addAll(commaDelimitedListToSet(request.getDeploymentProperties().get(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY)));
+        services.addAll(commaDelimitedListToSet(request.getDeploymentProperties().get(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY)));
 
         return services;
     }
@@ -471,12 +471,12 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 
     private int diskQuota(AppDeploymentRequest request) {
         return parseInt(
-            request.getDeploymentProperties().getOrDefault(CloudFoundryDeployerProperties.DISK_PROPERTY_KEY, valueOf(this.properties.getDisk())));
+            request.getDeploymentProperties().getOrDefault(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, valueOf(this.properties.getDisk())));
     }
 
     private int memory(AppDeploymentRequest request) {
         return parseInt(
-            request.getDeploymentProperties().getOrDefault(CloudFoundryDeployerProperties.MEMORY_PROPERTY_KEY, valueOf(this.properties.getMemory())));
+            request.getDeploymentProperties().getOrDefault(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, valueOf(this.properties.getMemory())));
     }
 
     private TaskStatus mapTaskToStatus(GetTaskResponse getTaskResponse) {

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -97,7 +97,7 @@ public class CloudFoundryAppDeployerTests {
 		applicationsV2 = mock(ApplicationsV2.class);
 		services = mock(Services.class);
 
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 		properties.setAppNamePrefix("dataflow-server");
 		//Tests are setup not to handle random name prefix = true;
 		properties.setEnableRandomAppNamePrefix(false);
@@ -137,7 +137,7 @@ public class CloudFoundryAppDeployerTests {
 	public void moveAppPropertiesToSAJ() throws InterruptedException, IOException {
 
 		// given
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 
 		// Define the deployment properties for the app
 		Map<String, String> deploymentProperties = new HashMap<>();

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGeneratorTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGeneratorTest.java
@@ -28,7 +28,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithAppNamePrefixAndRandomAppNamePrefixFalse() throws Exception {
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 		properties.setEnableRandomAppNamePrefix(false);
 		properties.setAppNamePrefix("dataflow");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -40,7 +40,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithAppNamePrefixAndRandomAppNamePrefixTrue() throws Exception {
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 		properties.setEnableRandomAppNamePrefix(true);
 		properties.setAppNamePrefix("dataflow-longername");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -59,7 +59,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithoutAppNamePrefixAndRandomAppNamePrefixTrue() throws Exception {
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 		properties.setEnableRandomAppNamePrefix(true);
 		properties.setAppNamePrefix("");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -74,7 +74,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithoutAppNamePrefixAndRandomAppNamePrefixFalse() throws Exception {
-		CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 		properties.setEnableRandomAppNamePrefix(false);
 		properties.setAppNamePrefix("");
 		CloudFoundryAppNameGenerator deploymentCustomizer =

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGeneratorTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppNameGeneratorTest.java
@@ -28,7 +28,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithAppNamePrefixAndRandomAppNamePrefixFalse() throws Exception {
-		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
+		CloudFoundryDeploymentProperties properties = new CloudFoundryDeploymentProperties();
 		properties.setEnableRandomAppNamePrefix(false);
 		properties.setAppNamePrefix("dataflow");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -40,7 +40,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithAppNamePrefixAndRandomAppNamePrefixTrue() throws Exception {
-		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
+		CloudFoundryDeploymentProperties properties = new CloudFoundryDeploymentProperties();
 		properties.setEnableRandomAppNamePrefix(true);
 		properties.setAppNamePrefix("dataflow-longername");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -59,7 +59,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithoutAppNamePrefixAndRandomAppNamePrefixTrue() throws Exception {
-		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
+		CloudFoundryDeploymentProperties properties = new CloudFoundryDeploymentProperties();
 		properties.setEnableRandomAppNamePrefix(true);
 		properties.setAppNamePrefix("");
 		CloudFoundryAppNameGenerator deploymentCustomizer =
@@ -74,7 +74,7 @@ public class CloudFoundryAppNameGeneratorTest {
 
 	@Test
 	public void testDeploymentIdWithoutAppNamePrefixAndRandomAppNamePrefixFalse() throws Exception {
-		CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
+		CloudFoundryDeploymentProperties properties = new CloudFoundryDeploymentProperties();
 		properties.setEnableRandomAppNamePrefix(false);
 		properties.setAppNamePrefix("");
 		CloudFoundryAppNameGenerator deploymentCustomizer =

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
@@ -53,7 +53,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Runs integration tests for {@link CloudFoundryTaskLauncher}, using the production configuration,
- * that may be configured via {@link CloudFoundryDeployerProperties}.
+ * that may be configured via {@link CloudFoundryConnectionProperties}.
  *
  * Tests are only run if a successful connection can be made at startup.
  *
@@ -91,9 +91,9 @@ public class CloudFoundryTaskLauncherIntegrationTests {
 		}
 
 		Map<String, String> envProperties = new HashMap<>();
-		envProperties.put(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY, "my_mysql");
-		envProperties.put(CloudFoundryDeployerProperties.MEMORY_PROPERTY_KEY, "1024");
-		envProperties.put(CloudFoundryDeployerProperties.DISK_PROPERTY_KEY, "2048");
+		envProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+		envProperties.put(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, "1024");
+		envProperties.put(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, "2048");
 
 		List<String> commandLineArgs = new ArrayList<>(3);
 		commandLineArgs.add("--foo=bar");
@@ -133,9 +133,9 @@ public class CloudFoundryTaskLauncherIntegrationTests {
 	@Test
 	public void testSimpleCancel() throws InterruptedException {
 		Map<String, String> envProperties = new HashMap<>();
-		envProperties.put(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY, "my_mysql");
-		envProperties.put(CloudFoundryDeployerProperties.MEMORY_PROPERTY_KEY, "1024");
-		envProperties.put(CloudFoundryDeployerProperties.DISK_PROPERTY_KEY, "2048");
+		envProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+		envProperties.put(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, "1024");
+		envProperties.put(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, "2048");
 
 		List<String> commandLineArgs = new ArrayList<>(2);
 		commandLineArgs.add("30000");

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
@@ -91,9 +91,9 @@ public class CloudFoundryTaskLauncherIntegrationTests {
 		}
 
 		Map<String, String> envProperties = new HashMap<>();
-		envProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
-		envProperties.put(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, "1024");
-		envProperties.put(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, "2048");
+		envProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+		envProperties.put(CloudFoundryDeploymentProperties.MEMORY_PROPERTY_KEY, "1024");
+		envProperties.put(CloudFoundryDeploymentProperties.DISK_PROPERTY_KEY, "2048");
 
 		List<String> commandLineArgs = new ArrayList<>(3);
 		commandLineArgs.add("--foo=bar");
@@ -133,9 +133,9 @@ public class CloudFoundryTaskLauncherIntegrationTests {
 	@Test
 	public void testSimpleCancel() throws InterruptedException {
 		Map<String, String> envProperties = new HashMap<>();
-		envProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
-		envProperties.put(CloudFoundryConnectionProperties.MEMORY_PROPERTY_KEY, "1024");
-		envProperties.put(CloudFoundryConnectionProperties.DISK_PROPERTY_KEY, "2048");
+		envProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+		envProperties.put(CloudFoundryDeploymentProperties.MEMORY_PROPERTY_KEY, "1024");
+		envProperties.put(CloudFoundryDeploymentProperties.DISK_PROPERTY_KEY, "2048");
 
 		List<String> commandLineArgs = new ArrayList<>(2);
 		commandLineArgs.add("30000");

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
@@ -115,7 +115,7 @@ public class CloudFoundryTaskLauncherTests {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        CloudFoundryDeployerProperties properties = new CloudFoundryDeployerProperties();
+        CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
 
         properties.setOrg("org");
         properties.setSpace("space");
@@ -523,7 +523,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),
@@ -610,7 +610,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
+        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),
@@ -699,7 +699,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryDeployerProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
+        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,11 +77,6 @@ import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
 import org.springframework.core.io.ClassPathResource;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-
 /**
  * @author Michael Minella
  */
@@ -115,12 +115,11 @@ public class CloudFoundryTaskLauncherTests {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        CloudFoundryConnectionProperties properties = new CloudFoundryConnectionProperties();
+        CloudFoundryConnectionProperties connectionProperties = new CloudFoundryConnectionProperties();
+        connectionProperties.setOrg("org");
+        connectionProperties.setSpace("space");
 
-        properties.setOrg("org");
-        properties.setSpace("space");
-
-        this.launcher = new CloudFoundryTaskLauncher(this.client, this.operations, properties);
+        this.launcher = new CloudFoundryTaskLauncher(this.client, this.operations, connectionProperties, new CloudFoundryDeploymentProperties());
     }
 
     @Test
@@ -523,7 +522,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_mysql");
+        environmentProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "my_mysql");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),
@@ -610,7 +609,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
+        environmentProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),
@@ -699,7 +698,7 @@ public class CloudFoundryTaskLauncherTests {
         Map<String,String> environmentProperties = new HashMap<>();
         environmentProperties.put("organization", "org");
         environmentProperties.put("space", "dev");
-        environmentProperties.put(CloudFoundryConnectionProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
+        environmentProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "my_service1,my_service2,my_service3");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition,
             new ClassPathResource("/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.class"),

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTestSupport.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTestSupport.java
@@ -62,12 +62,12 @@ public class CloudFoundryTestSupport extends AbstractExternalResourceTestSupport
 
 	@Configuration
 	@EnableAutoConfiguration
-	@EnableConfigurationProperties(CloudFoundryDeployerProperties.class)
+	@EnableConfigurationProperties(CloudFoundryConnectionProperties.class)
 	public static class Config {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public ConnectionContext connectionContext(CloudFoundryDeployerProperties properties) {
+		public ConnectionContext connectionContext(CloudFoundryConnectionProperties properties) {
 			return DefaultConnectionContext.builder()
 					.apiHost(properties.getUrl().getHost())
 					.skipSslValidation(properties.isSkipSslValidation())
@@ -76,7 +76,7 @@ public class CloudFoundryTestSupport extends AbstractExternalResourceTestSupport
 
 		@Bean
 		@ConditionalOnMissingBean
-		public TokenProvider tokenProvider(CloudFoundryDeployerProperties properties) {
+		public TokenProvider tokenProvider(CloudFoundryConnectionProperties properties) {
 			return PasswordGrantTokenProvider.builder()
 					.username(properties.getUsername())
 					.password(properties.getPassword())
@@ -96,7 +96,7 @@ public class CloudFoundryTestSupport extends AbstractExternalResourceTestSupport
 		public CloudFoundryOperations cloudFoundryOperations(CloudFoundryClient cloudFoundryClient,
 															 ConnectionContext connectionContext,
 															 TokenProvider tokenProvider,
-															 CloudFoundryDeployerProperties properties) {
+															 CloudFoundryConnectionProperties properties) {
 			ReactorDopplerClient.builder()
 				.connectionContext(connectionContext)
 				.tokenProvider(tokenProvider)


### PR DESCRIPTION
Also, add infrastructure so that the latter can be independently provided
for apps and tasks (with the default being to share a single instance).

Fixes spring-cloud/spring-cloud-deployer-cloudfoundry#66