### PR TITLE
Apps should be able to use a their own prefix for connection props

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Eric Bottard
  * @author Greg Turnquist
  */
-@ConfigurationProperties(prefix = CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES)
+
 public class CloudFoundryConnectionProperties {
 
 	/**

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.core.Ordered;
  * @author Eric Bottard
  */
 @Configuration
-@EnableConfigurationProperties(CloudFoundryConnectionProperties.class)
+@EnableConfigurationProperties
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 public class CloudFoundryDeployerAutoConfiguration {
 
@@ -67,9 +67,14 @@ public class CloudFoundryDeployerAutoConfiguration {
 	public CloudFoundryDeploymentProperties defaultSharedDeploymentProperties() {
 		return new CloudFoundryDeploymentProperties();
 	}
-
-
-
+	
+	@Bean
+	@ConditionalOnMissingBean
+	@ConfigurationProperties(prefix = CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES)
+	public CloudFoundryConnectionProperties cloudFoundryConnectionProperties() {
+		return new CloudFoundryConnectionProperties();
+	}
+	
 	@Bean
 	@ConditionalOnMissingBean
 	public ConnectionContext connectionContext(CloudFoundryConnectionProperties properties) {


### PR DESCRIPTION
This allows apps using the deployer to create a prefix other than the one specified by CLOUDFOUNDRY_PROPERTIES for deployment properties.
resolves #96