### PR TITLE
Use Cloud Foundry V2 APIs in TaskLauncher

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
@@ -1,0 +1,103 @@
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.time.Duration;
+import java.util.function.BiFunction;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.CloudFoundryException;
+import org.cloudfoundry.client.v3.tasks.CancelTaskRequest;
+import org.cloudfoundry.client.v3.tasks.CancelTaskResponse;
+import org.cloudfoundry.client.v3.tasks.GetTaskRequest;
+import org.cloudfoundry.client.v3.tasks.GetTaskResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.task.LaunchState;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import reactor.core.publisher.Mono;
+
+abstract class AbstractCloudFoundryTaskLauncher implements TaskLauncher {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractCloudFoundryTaskLauncher.class);
+
+	private final CloudFoundryClient client;
+
+	private final CloudFoundryDeploymentProperties deploymentProperties;
+
+	AbstractCloudFoundryTaskLauncher(CloudFoundryClient client, CloudFoundryDeploymentProperties deploymentProperties) {
+		this.client = client;
+		this.deploymentProperties = deploymentProperties;
+	}
+
+	/**
+	 * Setup a reactor flow to cancel a running task.  This implementation opts to be asynchronous.
+	 *
+	 * @param id the task's id to be canceled as returned from the {@link TaskLauncher#launch(AppDeploymentRequest)}
+	 */
+	@Override
+	public void cancel(String id) {
+		requestCancelTask(id)
+			.timeout(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()))
+			.doOnSuccess(r -> logger.info("Task {} cancellation successful", id))
+			.doOnError(t -> logger.error(String.format("Task %s cancellation failed", id), t))
+			.subscribe();
+	}
+
+	/**
+	 * Lookup the current status based on task id.
+	 *
+	 * @param id taskId as returned from the {@link TaskLauncher#launch(AppDeploymentRequest)}
+	 * @return the current task status
+	 */
+	@Override
+	public TaskStatus status(String id) {
+		return requestGetTask(id)
+			.map(this::toTaskStatus)
+			.otherwise(e -> toTaskStatus(e, id))
+			.doOnSuccess(r -> logger.info("Task {} status successful", id))
+			.doOnError(t -> logger.error(String.format("Task %s status failed", id), t))
+			.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
+	}
+
+	protected Mono<TaskStatus> toTaskStatus(Throwable throwable, String id) {
+		if ((throwable instanceof CloudFoundryException)
+			&& ((CloudFoundryException) throwable).getCode() == 10010) {
+			return Mono.just(new TaskStatus(id, LaunchState.unknown, null));
+		} else {
+			return Mono.error(throwable);
+		}
+	}
+
+	protected TaskStatus toTaskStatus(GetTaskResponse response) {
+		switch (response.getState()) {
+			case SUCCEEDED_STATE:
+				return new TaskStatus(response.getId(), LaunchState.complete, null);
+			case RUNNING_STATE:
+				return new TaskStatus(response.getId(), LaunchState.running, null);
+			case PENDING_STATE:
+				return new TaskStatus(response.getId(), LaunchState.launching, null);
+			case CANCELING_STATE:
+				return new TaskStatus(response.getId(), LaunchState.cancelled, null);
+			case FAILED_STATE:
+				return new TaskStatus(response.getId(), LaunchState.failed, null);
+			default:
+				throw new IllegalStateException(String.format("Unsupported CF task state %s", response.getState()));
+		}
+	}
+
+	private Mono<CancelTaskResponse> requestCancelTask(String taskId) {
+		return this.client.tasks()
+			.cancel(CancelTaskRequest.builder()
+				.taskId(taskId)
+				.build());
+	}
+
+	private Mono<GetTaskResponse> requestGetTask(String taskId) {
+		return this.client.tasks()
+			.get(GetTaskRequest.builder()
+				.taskId(taskId)
+				.build());
+	}
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncher.java
@@ -28,14 +28,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cloudfoundry.client.CloudFoundryClient;
-import org.cloudfoundry.client.v2.CloudFoundryException;
 import org.cloudfoundry.client.v3.BuildpackData;
 import org.cloudfoundry.client.v3.Lifecycle;
 import org.cloudfoundry.client.v3.Relationship;
@@ -64,12 +62,8 @@ import org.cloudfoundry.client.v3.servicebindings.CreateServiceBindingRequest;
 import org.cloudfoundry.client.v3.servicebindings.CreateServiceBindingResponse;
 import org.cloudfoundry.client.v3.servicebindings.Relationships;
 import org.cloudfoundry.client.v3.servicebindings.ServiceBindingType;
-import org.cloudfoundry.client.v3.tasks.CancelTaskRequest;
-import org.cloudfoundry.client.v3.tasks.CancelTaskResponse;
 import org.cloudfoundry.client.v3.tasks.CreateTaskRequest;
 import org.cloudfoundry.client.v3.tasks.CreateTaskResponse;
-import org.cloudfoundry.client.v3.tasks.GetTaskRequest;
-import org.cloudfoundry.client.v3.tasks.GetTaskResponse;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.services.ServiceInstance;
 import org.cloudfoundry.operations.spaces.GetSpaceRequest;
@@ -78,16 +72,13 @@ import org.cloudfoundry.util.DelayUtils;
 import org.cloudfoundry.util.PaginationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.util.StringUtils;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import org.springframework.cloud.deployer.spi.core.AppDefinition;
-import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.deployer.spi.task.LaunchState;
-import org.springframework.cloud.deployer.spi.task.TaskLauncher;
-import org.springframework.cloud.deployer.spi.task.TaskStatus;
-import org.springframework.util.StringUtils;
 
 /**
  * {@link TaskLauncher} implementation for CloudFoundry.  When a task is launched, if it has not previously been
@@ -98,11 +89,11 @@ import org.springframework.util.StringUtils;
  * @author Michael Minella
  * @author Ben Hale
  */
-public class CloudFoundryTaskLauncher implements TaskLauncher {
+public class CloudFoundry2620AndEarlierTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryTaskLauncher.class);
+	private static final Logger logger = LoggerFactory.getLogger(CloudFoundry2630AndLaterTaskLauncher.class);
 
 	private final CloudFoundryClient client;
 
@@ -112,28 +103,15 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 
 	private final String space;
 
-	public CloudFoundryTaskLauncher(CloudFoundryClient client,
-									CloudFoundryDeploymentProperties deploymentProperties,
-									CloudFoundryOperations operations,
-									String space) {
+	public CloudFoundry2620AndEarlierTaskLauncher(CloudFoundryClient client,
+												  CloudFoundryDeploymentProperties deploymentProperties,
+												  CloudFoundryOperations operations,
+												  String space) {
+		super(client, deploymentProperties);
 		this.client = client;
 		this.deploymentProperties = deploymentProperties;
 		this.operations = operations;
 		this.space = space;
-	}
-
-	/**
-	 * Setup a reactor flow to cancel a running task.  This implementation opts to be asynchronous.
-	 *
-	 * @param id the task's id to be canceled as returned from the {@link TaskLauncher#launch(AppDeploymentRequest)}
-	 */
-	@Override
-	public void cancel(String id) {
-		requestCancelTask(id)
-			.timeout(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()))
-			.doOnSuccess(r -> logger.info("Task {} cancellation successful", id))
-			.doOnError(t -> logger.error(String.format("Task %s cancellation failed", id), t))
-			.subscribe();
 	}
 
 	/**
@@ -148,23 +126,6 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 			.then(application -> launchTask(application.getId(), request))
 			.doOnSuccess(r -> logger.info("Task {} launch successful", request))
 			.doOnError(t -> logger.error(String.format("Task %s launch failed", request), t))
-			.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
-	}
-
-	/**
-	 * Lookup the current status based on task id.
-	 *
-	 * @param id taskId as returned from the {@link TaskLauncher#launch(AppDeploymentRequest)}
-	 * @return the current task status
-	 */
-	@Override
-	public TaskStatus status(String id) {
-		BiFunction<Throwable, String, Mono<TaskStatus>> recoverFrom404 = this::toTaskStatus;
-		return requestGetTask(id)
-			.map(this::toTaskStatus)
-			.otherwise(e -> recoverFrom404.apply(e, id))
-			.doOnSuccess(r -> logger.info("Task {} status successful", id))
-			.doOnError(t -> logger.error(String.format("Task %s status failed", id), t))
 			.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
 	}
 
@@ -216,9 +177,8 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 
 	private String getCommand(Droplet droplet, AppDeploymentRequest request) {
 		String defaultCommand = ((StagedResult) droplet.getResult()).getProcessTypes().get("web");
-		String command = Stream.concat(Stream.of(defaultCommand), request.getCommandlineArguments().stream())
-				.collect(Collectors.joining(" "));
-		return command;
+		return Stream.concat(Stream.of(defaultCommand), request.getCommandlineArguments().stream())
+			.collect(Collectors.joining(" "));
 	}
 
 	private int getDisk(AppDeploymentRequest request) {
@@ -229,10 +189,10 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 
 	private Mono<GetDropletResponse> getDroplet(String applicationId) {
 		return requestListDroplets(applicationId)
-				.single()
-				.map(DropletResource::getId)
-				// LISTing then GETting is currently necessary, as the listing redacts some information in its results
-				.then(this::requestGetDroplet);
+			.single()
+			.map(DropletResource::getId)
+			// LISTing then GETting is currently necessary, as the listing redacts some information in its results
+			.then(this::requestGetDroplet);
 	}
 
 	private Map<String, String> getEnvironmentVariables(Map<String, String> properties) {
@@ -274,13 +234,6 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 	private Mono<String> launchTask(String applicationId, AppDeploymentRequest request) {
 		return getDroplet(applicationId)
 			.then(droplet -> createTask(applicationId, droplet, request));
-	}
-
-	private Mono<CancelTaskResponse> requestCancelTask(String taskId) {
-		return this.client.tasks()
-			.cancel(CancelTaskRequest.builder()
-				.taskId(taskId)
-				.build());
 	}
 
 	private Mono<Application> requestCreateApplication(String buildpack, Map<String, String> environmentVariables, String name, String spaceId) {
@@ -351,13 +304,6 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 				.build());
 	}
 
-	private Mono<GetTaskResponse> requestGetTask(String taskId) {
-		return this.client.tasks()
-			.get(GetTaskRequest.builder()
-				.taskId(taskId)
-				.build());
-	}
-
 	private Flux<Application> requestListApplications(String name) {
 		return PaginationUtils
 			.requestClientV3Resources(page -> this.client.applicationsV3()
@@ -404,33 +350,6 @@ public class CloudFoundryTaskLauncher implements TaskLauncher {
 				.bits(bits)
 				.packageId(packageId)
 				.build());
-	}
-
-	private Mono<TaskStatus> toTaskStatus(Throwable throwable, String id) {
-		if ((throwable instanceof CloudFoundryException)
-			&& ((CloudFoundryException) throwable).getCode() == 10010) {
-			return Mono.just(new TaskStatus(id, LaunchState.unknown, null));
-		}
-		else {
-			return Mono.error(throwable);
-		}
-	}
-
-	private TaskStatus toTaskStatus(GetTaskResponse response) {
-		switch (response.getState()) {
-			case SUCCEEDED_STATE:
-				return new TaskStatus(response.getId(), LaunchState.complete, null);
-			case RUNNING_STATE:
-				return new TaskStatus(response.getId(), LaunchState.running, null);
-			case PENDING_STATE:
-				return new TaskStatus(response.getId(), LaunchState.launching, null);
-			case CANCELING_STATE:
-				return new TaskStatus(response.getId(), LaunchState.cancelled, null);
-			case FAILED_STATE:
-				return new TaskStatus(response.getId(), LaunchState.failed, null);
-			default:
-				throw new IllegalStateException(String.format("Unsupported CF task state %s", response.getState()));
-		}
 	}
 
 	private Mono<GetDropletResponse> uploadPackage(AppDeploymentRequest request, String applicationId) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.DISK_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.MEMORY_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.applications.SummaryApplicationResponse;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationRequest;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationResponse;
+import org.cloudfoundry.client.v3.tasks.CreateTaskRequest;
+import org.cloudfoundry.client.v3.tasks.CreateTaskResponse;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.applications.AbstractApplicationSummary;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.applications.ApplicationHealthCheck;
+import org.cloudfoundry.operations.applications.ApplicationSummary;
+import org.cloudfoundry.operations.applications.GetApplicationRequest;
+import org.cloudfoundry.operations.applications.PushApplicationRequest;
+import org.cloudfoundry.operations.applications.StartApplicationRequest;
+import org.cloudfoundry.operations.applications.StopApplicationRequest;
+import org.cloudfoundry.operations.services.BindServiceInstanceRequest;
+import org.cloudfoundry.operations.services.ServiceInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.util.StringUtils;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link TaskLauncher} implementation for CloudFoundry.  When a task is launched, if it has not previously been
+ * deployed, the app is created, the package is uploaded, and the droplet is created before launching the actual
+ * task.  If the app has been deployed previously, the app/package/droplet is reused and a new task is created.
+ *
+ * @author Greg Turnquist
+ * @author Michael Minella
+ * @author Ben Hale
+ */
+public class CloudFoundry2630AndLaterTaskLauncher extends AbstractCloudFoundryTaskLauncher {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private static final Logger logger = LoggerFactory.getLogger(CloudFoundry2630AndLaterTaskLauncher.class);
+
+	private final CloudFoundryClient client;
+
+	private final CloudFoundryDeploymentProperties deploymentProperties;
+
+	private final CloudFoundryOperations operations;
+
+	public CloudFoundry2630AndLaterTaskLauncher(CloudFoundryClient client,
+												CloudFoundryDeploymentProperties deploymentProperties,
+												CloudFoundryOperations operations) {
+		super(client, deploymentProperties);
+		this.client = client;
+		this.deploymentProperties = deploymentProperties;
+		this.operations = operations;
+	}
+
+	/**
+	 * Set up a reactor flow to launch a task. Before launch, check if the base application exists. If not, deploy then launch task.
+	 *
+	 * @param request description of the application to be launched
+	 * @return name of the launched task, returned without waiting for reactor pipeline to complete
+	 */
+	@Override
+	public String launch(AppDeploymentRequest request) {
+		return getOrDeployApplication(request)
+			.then(application -> launchTask(application, request))
+			.doOnSuccess(r -> logger.info("Task {} launch successful", request))
+			.doOnError(t -> logger.error(String.format("Task %s launch failed", request), t))
+			.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
+	}
+
+	private Mono<Void> bindServices(String name, AppDeploymentRequest request) {
+		Set<String> servicesToBind = servicesToBind(request);
+
+		return requestListServiceInstances()
+			.filter(serviceInstance -> servicesToBind.contains(serviceInstance.getName()))
+			.flatMap(serviceInstance -> requestBindService(name, serviceInstance.getName()))
+			.then();
+	}
+
+	private String buildpack(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(BUILDPACK_PROPERTY_KEY))
+			.orElse(this.deploymentProperties.getBuildpack());
+	}
+
+	private Mono<AbstractApplicationSummary> deployApplication(AppDeploymentRequest request) {
+		String name = request.getDefinition().getName();
+
+		return pushApplication(name, request)
+			.then(requestGetApplication(name))
+			.then(application -> setEnvironmentVariables(application.getId(), getEnvironmentVariables(request.getDefinition().getProperties()))
+				.then(bindServices(name, request))
+				.then(startApplication(name))
+				.then(stopApplication(name))
+				.then(Mono.just(application)));
+	}
+
+	private int diskQuota(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(DISK_PROPERTY_KEY))
+			.map(Integer::parseInt)
+			.orElse(this.deploymentProperties.getDisk());
+	}
+
+	private Path getApplication(AppDeploymentRequest request) {
+		try {
+			return request.getResource().getFile().toPath();
+		} catch (IOException e) {
+			throw Exceptions.propagate(e);
+		}
+	}
+
+	private String getCommand(SummaryApplicationResponse application, AppDeploymentRequest request) {
+		return Stream.concat(Stream.of(application.getDetectedStartCommand()), request.getCommandlineArguments().stream())
+			.collect(Collectors.joining(" "));
+	}
+
+	private Map<String, String> getEnvironmentVariables(Map<String, String> properties) {
+		try {
+			return Collections.singletonMap("SPRING_APPLICATION_JSON", OBJECT_MAPPER.writeValueAsString(properties));
+		} catch (JsonProcessingException e) {
+			throw Exceptions.propagate(e);
+		}
+	}
+
+	private Mono<AbstractApplicationSummary> getOptionalApplication(AppDeploymentRequest request) {
+		String name = request.getDefinition().getName();
+
+		return requestListApplications()
+			.filter(application -> name.equals(application.getName()))
+			.singleOrEmpty()
+			.cast(AbstractApplicationSummary.class);
+	}
+
+	private Mono<SummaryApplicationResponse> getOrDeployApplication(AppDeploymentRequest request) {
+		return getOptionalApplication(request)
+			.otherwiseIfEmpty(deployApplication(request))
+			.then(application -> requestGetApplicationSummary(application.getId()));
+	}
+
+	private Mono<String> launchTask(SummaryApplicationResponse application, AppDeploymentRequest request) {
+		return requestCreateTask(application.getId(), getCommand(application, request), memory(request), request.getDefinition().getName())
+			.map(CreateTaskResponse::getId);
+	}
+
+	private int memory(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(MEMORY_PROPERTY_KEY))
+			.map(Integer::parseInt)
+			.orElse(this.deploymentProperties.getMemory());
+	}
+
+	private Mono<Void> pushApplication(String name, AppDeploymentRequest request) {
+		return requestPushApplication(PushApplicationRequest.builder()
+			.application(getApplication(request))
+			.buildpack(buildpack(request))
+			.command("/bin/nc -l $PORT")
+			.diskQuota(diskQuota(request))
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(memory(request))
+			.name(name)
+			.noRoute(true)
+			.noStart(true)
+			.build());
+	}
+
+	private Mono<Void> requestBindService(String applicationName, String serviceInstanceName) {
+		return this.operations.services()
+			.bind(BindServiceInstanceRequest.builder()
+				.applicationName(applicationName)
+				.serviceInstanceName(serviceInstanceName)
+				.build());
+	}
+
+	private Mono<CreateTaskResponse> requestCreateTask(String applicationId, String command, int memory, String name) {
+		return this.client.tasks()
+			.create(CreateTaskRequest.builder()
+				.applicationId(applicationId)
+				.command(command)
+				.memoryInMb(memory)
+				.name(name)
+				.build());
+	}
+
+	private Mono<ApplicationDetail> requestGetApplication(String name) {
+		return this.operations.applications()
+			.get(GetApplicationRequest.builder()
+				.name(name)
+				.build());
+	}
+
+	private Mono<SummaryApplicationResponse> requestGetApplicationSummary(String applicationId) {
+		return this.client.applicationsV2()
+			.summary(org.cloudfoundry.client.v2.applications.SummaryApplicationRequest.builder()
+				.applicationId(applicationId)
+				.build());
+	}
+
+	private Flux<ApplicationSummary> requestListApplications() {
+		return this.operations.applications()
+			.list();
+	}
+
+	private Flux<ServiceInstance> requestListServiceInstances() {
+		return this.operations.services()
+			.listInstances();
+	}
+
+	private Mono<Void> requestPushApplication(PushApplicationRequest request) {
+		return this.operations.applications()
+			.push(request);
+	}
+
+	private Mono<Void> requestStartApplication(String name, Duration stagingTimeout, Duration startupTimeout) {
+		return this.operations.applications()
+			.start(StartApplicationRequest.builder()
+				.name(name)
+				.stagingTimeout(stagingTimeout)
+				.startupTimeout(startupTimeout)
+				.build());
+	}
+
+	private Mono<Void> requestStopApplication(String name) {
+		return this.operations.applications()
+			.stop(StopApplicationRequest.builder()
+				.name(name)
+				.build());
+	}
+
+	private Mono<UpdateApplicationResponse> requestUpdateApplication(String applicationId, Map<String, String> environmentVariables) {
+		return this.client.applicationsV2()
+			.update(UpdateApplicationRequest.builder()
+				.applicationId(applicationId)
+				.environmentJsons(environmentVariables)
+				.build());
+	}
+
+	private Set<String> servicesToBind(AppDeploymentRequest request) {
+		Set<String> services = new HashSet<>();
+		services.addAll(this.deploymentProperties.getServices());
+		services.addAll(StringUtils.commaDelimitedListToSet(request.getDeploymentProperties().get(SERVICES_PROPERTY_KEY)));
+		return services;
+	}
+
+	private Mono<UpdateApplicationResponse> setEnvironmentVariables(String applicationId, Map<String, String> environmentVariables) {
+		return requestUpdateApplication(applicationId, environmentVariables);
+	}
+
+	private Mono<Void> startApplication(String name) {
+		return requestStartApplication(name, this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStartupTimeout());
+	}
+
+	private Mono<Void> stopApplication(String name) {
+		return requestStopApplication(name);
+	}
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -53,16 +53,15 @@ import org.cloudfoundry.operations.applications.StartApplicationRequest;
 import org.cloudfoundry.operations.services.BindServiceInstanceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
-import reactor.core.Exceptions;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.util.StringUtils;
+import org.yaml.snakeyaml.Yaml;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * A deployer that targets Cloud Foundry using the public API.
@@ -75,7 +74,7 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryTaskLauncher.class);
+	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryAppDeployer.class);
 
 	private final AppNameGenerator applicationNameGenerator;
 
@@ -98,11 +97,11 @@ public class CloudFoundryAppDeployer implements AppDeployer {
 		String deploymentId = deploymentId(request);
 
 		getStatus(deploymentId)
-				.doOnNext(status -> assertApplicationDoesNotExist(deploymentId, status))
-				// Need to block here to be able to throw exception early
-				.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
-		Mono.empty()
-			.then(pushApplication(deploymentId, request))
+			.doOnNext(status -> assertApplicationDoesNotExist(deploymentId, status))
+			// Need to block here to be able to throw exception early
+			.block(Duration.ofSeconds(this.deploymentProperties.getTaskTimeout()));
+
+		pushApplication(deploymentId, request)
 			.then(setEnvironmentVariables(deploymentId, getEnvironmentVariables(deploymentId, request)))
 			.then(bindServices(deploymentId, request))
 			.then(startApplication(deploymentId))

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncherTests.java
@@ -94,7 +94,7 @@ import org.springframework.core.io.Resource;
  * @author Michael Minella
  * @author Ben Hale
  */
-public class CloudFoundryTaskLauncherTests {
+public class CloudFoundry2620AndEarlierTaskLauncherTests {
 
 	private final CloudFoundryDeploymentProperties deploymentProperties = new CloudFoundryDeploymentProperties();
 
@@ -110,7 +110,7 @@ public class CloudFoundryTaskLauncherTests {
 	@Mock(answer = Answers.RETURNS_SMART_NULLS)
 	private InputStream inputStream;
 
-	private CloudFoundryTaskLauncher launcher;
+	private CloudFoundry2620AndEarlierTaskLauncher launcher;
 
 	@Mock(answer = Answers.RETURNS_SMART_NULLS)
 	private CloudFoundryOperations operations;
@@ -234,7 +234,7 @@ public class CloudFoundryTaskLauncherTests {
 					.build())
 				.id("test-droplet-id")
 				.build())
-			);
+		);
 
 		givenRequestListServiceInstances(Flux.empty());
 
@@ -778,7 +778,7 @@ public class CloudFoundryTaskLauncherTests {
 		given(this.resource.getInputStream()).willReturn(this.inputStream);
 
 		this.deploymentProperties.setTaskTimeout(1);
-		this.launcher = new CloudFoundryTaskLauncher(this.client, this.deploymentProperties, this.operations, "test-space");
+		this.launcher = new CloudFoundry2620AndEarlierTaskLauncher(this.client, this.deploymentProperties, this.operations, "test-space");
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncherTests.java
@@ -1,0 +1,805 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.applications.ApplicationsV2;
+import org.cloudfoundry.client.v2.applications.SummaryApplicationResponse;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationRequest;
+import org.cloudfoundry.client.v2.applications.UpdateApplicationResponse;
+import org.cloudfoundry.client.v3.tasks.CancelTaskRequest;
+import org.cloudfoundry.client.v3.tasks.CancelTaskResponse;
+import org.cloudfoundry.client.v3.tasks.CreateTaskRequest;
+import org.cloudfoundry.client.v3.tasks.CreateTaskResponse;
+import org.cloudfoundry.client.v3.tasks.GetTaskRequest;
+import org.cloudfoundry.client.v3.tasks.GetTaskResponse;
+import org.cloudfoundry.client.v3.tasks.Tasks;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.applications.ApplicationHealthCheck;
+import org.cloudfoundry.operations.applications.ApplicationSummary;
+import org.cloudfoundry.operations.applications.Applications;
+import org.cloudfoundry.operations.applications.GetApplicationRequest;
+import org.cloudfoundry.operations.applications.PushApplicationRequest;
+import org.cloudfoundry.operations.applications.StartApplicationRequest;
+import org.cloudfoundry.operations.applications.StopApplicationRequest;
+import org.cloudfoundry.operations.services.BindServiceInstanceRequest;
+import org.cloudfoundry.operations.services.ServiceInstance;
+import org.cloudfoundry.operations.services.ServiceInstanceType;
+import org.cloudfoundry.operations.services.Services;
+import org.cloudfoundry.operations.spaces.Spaces;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.task.LaunchState;
+import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Michael Minella
+ * @author Ben Hale
+ */
+public class CloudFoundry2630AndLaterTaskLauncherTests {
+
+	private final CloudFoundryDeploymentProperties deploymentProperties = new CloudFoundryDeploymentProperties();
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private Applications applications;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private ApplicationsV2 applicationsV2;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private CloudFoundryClient client;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private InputStream inputStream;
+
+	private CloudFoundry2630AndLaterTaskLauncher launcher;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private CloudFoundryOperations operations;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private Services services;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private Spaces spaces;
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private Tasks tasks;
+
+	@Test
+	public void cancel() {
+		givenRequestCancelTask("test-task-id", Mono.just(CancelTaskResponse.builder()
+			.id("test-task-id")
+			.state(org.cloudfoundry.client.v3.tasks.State.CANCELING_STATE)
+			.build()));
+
+		this.launcher.cancel("test-task-id");
+	}
+
+	@Test
+	public void launchTaskApplicationExists() {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.just(ApplicationSummary.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.build()));
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.just(SummaryApplicationResponse.builder()
+			.id("test-application-id")
+			.detectedStartCommand("test-command")
+			.build()));
+
+		givenRequestCreateTask("test-application-id", "test-command", this.deploymentProperties.getMemory(), "test-application", Mono.just(CreateTaskResponse.builder()
+			.id("test-task-id")
+			.build()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		String taskId = this.launcher.launch(request);
+
+		assertThat(taskId, equalTo("test-task-id"));
+	}
+
+	@Test
+	public void launchTaskWithNonExistentApplication() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.empty());
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.just(SummaryApplicationResponse.builder()
+			.id("test-application-id")
+			.detectedStartCommand("test-command")
+			.build()));
+
+		givenRequestCreateTask("test-application-id", "test-command", this.deploymentProperties.getMemory(), "test-application", Mono.just(CreateTaskResponse.builder()
+			.id("test-task-id")
+			.build()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		String taskId = this.launcher.launch(request);
+
+		assertThat(taskId, equalTo("test-task-id"));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndApplicationListingFails() {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndListingServiceFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndPushFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndRetrievingApplicationSummaryFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.empty());
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndStartingApplicationFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.error(new UnsupportedOperationException
+			()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndStoppingApplicationFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndTaskCreationFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.empty());
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.just(SummaryApplicationResponse.builder()
+			.id("test-application-id")
+			.detectedStartCommand("test-command")
+			.build()));
+
+		givenRequestCreateTask("test-application-id", "test-command", this.deploymentProperties.getMemory(), "test-application", Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationAndUpdatingApplicationFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Test
+	public void launchTaskWithNonExistentApplicationBindingOneService() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.just(ServiceInstance.builder()
+				.id("test-service-instance-id-1")
+				.name("test-service-instance-1")
+				.type(ServiceInstanceType.MANAGED)
+				.build(),
+			ServiceInstance.builder()
+				.id("test-service-instance-id-2")
+				.name("test-service-instance-2")
+				.type(ServiceInstanceType.MANAGED)
+				.build()));
+
+		givenRequestBindService("test-application", "test-service-instance-2", Mono.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.empty());
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.just(SummaryApplicationResponse.builder()
+			.id("test-application-id")
+			.detectedStartCommand("test-command")
+			.build()));
+
+		givenRequestCreateTask("test-application-id", "test-command", this.deploymentProperties.getMemory(), "test-application", Mono.just(CreateTaskResponse.builder()
+			.id("test-task-id")
+			.build()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource,
+			Collections.singletonMap(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "test-service-instance-2"));
+
+		String taskId = this.launcher.launch(request);
+
+		assertThat(taskId, equalTo("test-task-id"));
+		verifyRequestBindService("test-application", "test-service-instance-2");
+	}
+
+	@Test
+	public void launchTaskWithNonExistentApplicationBindingThreeServices() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.just(ApplicationDetail.builder()
+			.diskQuota(0)
+			.id("test-application-id")
+			.instances(1)
+			.memoryLimit(0)
+			.name("test-application")
+			.requestedState("RUNNING")
+			.runningInstances(1)
+			.stack("test-stack")
+			.build()));
+
+		givenRequestUpdateApplication("test-application-id", Collections.singletonMap("SPRING_APPLICATION_JSON", "{}"), Mono.empty());
+
+		givenRequestListServiceInstances(Flux.just(ServiceInstance.builder()
+				.id("test-service-instance-id-1")
+				.name("test-service-instance-1")
+				.type(ServiceInstanceType.MANAGED)
+				.build(),
+			ServiceInstance.builder()
+				.id("test-service-instance-id-2")
+				.name("test-service-instance-2")
+				.type(ServiceInstanceType.MANAGED)
+				.build(),
+			ServiceInstance.builder()
+				.id("test-service-instance-id-3")
+				.name("test-service-instance-3")
+				.type(ServiceInstanceType.MANAGED)
+				.build()));
+
+		givenRequestBindService("test-application", "test-service-instance-1", Mono.empty());
+
+		givenRequestBindService("test-application", "test-service-instance-2", Mono.empty());
+
+		givenRequestBindService("test-application", "test-service-instance-3", Mono.empty());
+
+		givenRequestStartApplication("test-application", this.deploymentProperties.getStagingTimeout(), this.deploymentProperties.getStagingTimeout(), Mono.empty());
+
+		givenRequestStopApplication("test-application", Mono.empty());
+
+		givenRequestGetApplicationSummary("test-application-id", Mono.just(SummaryApplicationResponse.builder()
+			.id("test-application-id")
+			.detectedStartCommand("test-command")
+			.build()));
+
+		givenRequestCreateTask("test-application-id", "test-command", this.deploymentProperties.getMemory(), "test-application", Mono.just(CreateTaskResponse.builder()
+			.id("test-task-id")
+			.build()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource,
+			Collections.singletonMap(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, "test-service-instance-1,test-service-instance-2,test-service-instance-3"));
+
+		String taskId = this.launcher.launch(request);
+
+		assertThat(taskId, equalTo("test-task-id"));
+		verifyRequestBindService("test-application", "test-service-instance-1");
+		verifyRequestBindService("test-application", "test-service-instance-2");
+		verifyRequestBindService("test-application", "test-service-instance-3");
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void launchTaskWithNonExistentApplicationRetrievalFails() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		givenRequestListApplications(Flux.empty());
+
+		givenRequestPushApplication(PushApplicationRequest.builder()
+			.application(resource.getFile().toPath())
+			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.command("/bin/nc -l $PORT")
+			.diskQuota(this.deploymentProperties.getDisk())
+			.healthCheckType(ApplicationHealthCheck.NONE)
+			.memory(this.deploymentProperties.getMemory())
+			.name("test-application")
+			.noRoute(true)
+			.noStart(true)
+			.build(), Mono.empty());
+
+		givenRequestGetApplication("test-application", Mono.error(new UnsupportedOperationException()));
+
+		AppDefinition definition = new AppDefinition("test-application", null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.emptyMap());
+
+		this.launcher.launch(request);
+	}
+
+	@Before
+	public void setUp() throws IOException {
+		MockitoAnnotations.initMocks(this);
+		given(this.client.applicationsV2()).willReturn(this.applicationsV2);
+		given(this.client.tasks()).willReturn(this.tasks);
+
+		given(this.operations.applications()).willReturn(this.applications);
+		given(this.operations.services()).willReturn(this.services);
+		given(this.operations.spaces()).willReturn(this.spaces);
+
+		this.deploymentProperties.setTaskTimeout(1);
+		this.launcher = new CloudFoundry2630AndLaterTaskLauncher(this.client, this.deploymentProperties, this.operations);
+	}
+
+	@Test
+	public void status() {
+		givenRequestGetTask("test-task-id", Mono.just(GetTaskResponse.builder()
+			.id("test-task-id")
+			.state(org.cloudfoundry.client.v3.tasks.State.SUCCEEDED_STATE)
+			.build()));
+
+		TaskStatus status = this.launcher.status("test-task-id");
+
+		assertThat(status.getState(), equalTo(LaunchState.complete));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testStatusTimeout() {
+		givenRequestGetTask("test-task-id", Mono
+			.delay(Duration.ofSeconds(2))
+			.then(Mono.just(GetTaskResponse.builder()
+				.id("test-task-id")
+				.state(org.cloudfoundry.client.v3.tasks.State.SUCCEEDED_STATE)
+				.build())));
+
+		this.launcher.status("test-task-id");
+	}
+
+	private void givenRequestBindService(String applicationName, String serviceInstanceName, Mono<Void> response) {
+		given(this.operations.services()
+			.bind(BindServiceInstanceRequest.builder()
+				.applicationName(applicationName)
+				.serviceInstanceName(serviceInstanceName)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestCancelTask(String taskId, Mono<CancelTaskResponse> response) {
+		given(this.client.tasks()
+			.cancel(CancelTaskRequest.builder()
+				.taskId(taskId)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestCreateTask(String applicationId, String command, int memory, String name, Mono<CreateTaskResponse> response) {
+		given(this.client.tasks()
+			.create(CreateTaskRequest.builder()
+				.applicationId(applicationId)
+				.command(command)
+				.memoryInMb(memory)
+				.name(name)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestGetApplication(String name, Mono<ApplicationDetail> response) {
+		given(this.operations.applications()
+			.get(GetApplicationRequest.builder()
+				.name(name)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestGetApplicationSummary(String applicationId, Mono<SummaryApplicationResponse> response) {
+		given(this.client.applicationsV2()
+			.summary(org.cloudfoundry.client.v2.applications.SummaryApplicationRequest.builder()
+				.applicationId(applicationId)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestGetTask(String taskId, Mono<GetTaskResponse> response) {
+		given(this.client.tasks()
+			.get(GetTaskRequest.builder()
+				.taskId(taskId)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestListApplications(Flux<ApplicationSummary> response) {
+		given(this.operations.applications()
+			.list())
+			.willReturn(response);
+	}
+
+	private void givenRequestListServiceInstances(Flux<ServiceInstance> response) {
+		given(this.operations.services()
+			.listInstances())
+			.willReturn(response);
+	}
+
+	private void givenRequestPushApplication(PushApplicationRequest request, Mono<Void> response) {
+		given(this.operations.applications()
+			.push(request))
+			.willReturn(response);
+	}
+
+	private void givenRequestStartApplication(String name, Duration stagingTimeout, Duration startupTimeout, Mono<Void> response) {
+		given(this.operations.applications()
+			.start(StartApplicationRequest.builder()
+				.name(name)
+				.stagingTimeout(stagingTimeout)
+				.startupTimeout(startupTimeout)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestStopApplication(String name, Mono<Void> response) {
+		given(this.operations.applications()
+			.stop(StopApplicationRequest.builder()
+				.name(name)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void givenRequestUpdateApplication(String applicationId, Map<String, String> environmentVariables, Mono<UpdateApplicationResponse> response) {
+		given(this.client.applicationsV2()
+			.update(UpdateApplicationRequest.builder()
+				.applicationId(applicationId)
+				.environmentJsons(environmentVariables)
+				.build()))
+			.willReturn(response);
+	}
+
+	private void verifyRequestBindService(String applicationName, String serviceInstanceName) {
+		verify(this.operations.services())
+			.bind(BindServiceInstanceRequest.builder()
+				.applicationName(applicationName)
+				.serviceInstanceName(serviceInstanceName)
+				.build());
+	}
+
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherIntegrationTests.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Runs integration tests for {@link CloudFoundryTaskLauncher}, using the production configuration,
+ * Runs integration tests for {@link CloudFoundry2630AndLaterTaskLauncher}, using the production configuration,
  * that may be configured via {@link CloudFoundryConnectionProperties}.
  *
  * Tests are only run if a successful connection can be made at startup.
@@ -44,7 +44,7 @@ public class CloudFoundryTaskLauncherIntegrationTests extends AbstractTaskLaunch
 	public static CloudFoundryTestSupport cfAvailable = new CloudFoundryTestSupport();
 
 	@Autowired
-	private CloudFoundryTaskLauncher taskLauncher;
+	private TaskLauncher taskLauncher;
 
 	@Override
 	protected TaskLauncher taskLauncher() {


### PR DESCRIPTION
Previously, the `TaskLauncher` was implemented exclusively using Cloud Foundry V3 APIs.  This was done because tasks are part of the V3 API and build on other V3 APIs.  Recently the Cloud Foundry team has requested that we use V2 APIs wherever possible and only use V3 APIs for tasks themselves.  This change updates the code to do that.