### PR TITLE
Better Identify Not Found Tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-deployer-spi.version>1.1.0.RELEASE</spring-cloud-deployer-spi.version>
-		<cloudfoundry-java-lib.version>2.1.0.RELEASE</cloudfoundry-java-lib.version>
+		<cloudfoundry-java-lib.version>2.2.0.BUILD-SNAPSHOT</cloudfoundry-java-lib.version>
 		<reactor-core.version>3.0.4.RELEASE</reactor-core.version>
 		<reactor-netty.version>0.6.0.RELEASE</reactor-netty.version>
 	</properties>

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2620AndEarlierTaskLauncher.java
@@ -122,8 +122,8 @@ public class CloudFoundry2620AndEarlierTaskLauncher extends AbstractCloudFoundry
 	public String launch(AppDeploymentRequest request) {
 		return getOrDeployApplication(request)
 			.then(application -> launchTask(application.getId(), request))
-			.doOnSuccess(r -> logger.info("Task {} launch successful", request))
-			.doOnError(t -> logger.error(String.format("Task %s launch failed", request), t))
+			.doOnSuccess(r -> logger.info("Task {} launch successful", request.getDefinition().getName()))
+			.doOnError(t -> logger.error(String.format("Task %s launch failed", request.getDefinition().getName()), t))
 			.block(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
@@ -94,8 +94,8 @@ public class CloudFoundry2630AndLaterTaskLauncher extends AbstractCloudFoundryTa
 	public String launch(AppDeploymentRequest request) {
 		return getOrDeployApplication(request)
 			.then(application -> launchTask(application, request))
-			.doOnSuccess(r -> logger.info("Task {} launch successful", request))
-			.doOnError(t -> logger.error(String.format("Task %s launch failed", request), t))
+			.doOnSuccess(r -> logger.info("Task {} launch successful", request.getDefinition().getName()))
+			.doOnError(t -> logger.error(String.format("Task %s launch failed", request.getDefinition().getName()), t))
 			.block(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}
 


### PR DESCRIPTION
Previously, the algorithm for identifying when a task was not found was brittle.  Not only did it examine payload codes and messages, when presented with an unexpected error payload (say across incompatible API changes), it would fail completely.

This change updates the algorithm to take advantage of updates to the Java Client.  Specifically, all CAPI-based APIs now return a subclass of AbstractCloudFoundryException which includes the original HTTP status code, even in the face of an unexpected error payload.  The existence of a 404 NOT FOUND HTTP status code is now the only indication that the task was not found.

In addition to this Java Client API change, the code was also updated to use the much more concise otherwiseReturn() operator in Reactor.  This greatly simplifies the logic and improves understandability.