### PR TITLE
Set default status timeout value to 2000.  New retry operation heuristic

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -107,7 +107,7 @@ public class CloudFoundryDeploymentProperties {
 	/**
 	 * Timeout for status API operations in milliseconds
 	 */
-	private long statusTimeout = 1_000L;
+	private long statusTimeout = 2_000L;
 
 	/**
 	 * Flag to indicate whether application properties are fed into SPRING_APPLICATION_JSON or ENVIRONMENT VARIABLES.


### PR DESCRIPTION
* Retry operation heuristics is 0.4*statusTimeout, 500 ms with defaults.
* Check that retry timeout value is never less than 500 ms, log and reset to
  500ms if that is the case.

Fixes #143 