### PR TITLE
Switching to use tag v3.14 for java-buildpack

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -70,7 +70,7 @@ public class CloudFoundryDeploymentProperties {
 	/**
 	 * The buildpack to use for deploying the application.
 	 */
-	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git";
+	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git#v3.14";
 
 	/**
 	 * The amount of memory to allocate, if not overridden per-app. Default unit is mebibytes, 'M' and 'G" suffixes supported.

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncherTests.java
@@ -171,7 +171,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -237,7 +237,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -276,7 +276,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -300,7 +300,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -345,7 +345,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -387,7 +387,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -430,7 +430,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -480,7 +480,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -517,7 +517,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -584,7 +584,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)
@@ -662,7 +662,7 @@ public class CloudFoundry2630AndLaterTaskLauncherTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 			.diskQuota((int) ByteSizeUtils.parseToMebibytes( this.deploymentProperties.getDisk()))
 			.healthCheckType(ApplicationHealthCheck.NONE)

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -144,7 +144,7 @@ public class CloudFoundryAppDeployerTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.diskQuota(1024)
 			.instances(1)
 			.memory(1024)
@@ -196,7 +196,7 @@ public class CloudFoundryAppDeployerTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.diskQuota(1024)
 			.instances(1)
 			.memory(1024)
@@ -251,7 +251,7 @@ public class CloudFoundryAppDeployerTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.diskQuota(1024)
 			.instances(1)
 			.memory(1024)
@@ -433,7 +433,7 @@ public class CloudFoundryAppDeployerTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.application(resource.getFile().toPath())
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.diskQuota(1024)
 			.instances(1)
 			.memory(1024)
@@ -495,7 +495,7 @@ public class CloudFoundryAppDeployerTests {
 
 		givenRequestPushApplication(PushApplicationRequest.builder()
 			.dockerImage("somecorp/someimage:latest")
-			.buildpack("https://github.com/cloudfoundry/java-buildpack.git")
+			.buildpack(deploymentProperties.getBuildpack())
 			.diskQuota(1024)
 			.instances(1)
 			.memory(1024)


### PR DESCRIPTION
- updating tests to use buildpack property from CloudFoundryDeploymentProperties

Resolves #173
