### PR TITLE
Add support for correlation with external metrics collector in deployer

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -276,6 +276,8 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 		if (group != null) {
 			envVariables.put("SPRING_CLOUD_APPLICATION_GROUP", group);
 		}
+		envVariables.put("SPRING_CLOUD_APPLICATION_GUID", "${vcap.application.name}:${vcap.application.instance_index}");
+		envVariables.put("SPRING_APPLICATION_INDEX", "${vcap.application.instance_index}");
 		return envVariables;
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppInstanceStatus.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppInstanceStatus.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.cloudfoundry.operations.applications.ApplicationDetail;
 import org.cloudfoundry.operations.applications.InstanceDetail;
@@ -37,6 +37,8 @@ public class CloudFoundryAppInstanceStatus implements AppInstanceStatus {
 	private final ApplicationDetail applicationDetail;
 
 	private final int index;
+
+	private final Map<String, String> attributes = new TreeMap<>();
 
 	public CloudFoundryAppInstanceStatus(ApplicationDetail applicationDetail, InstanceDetail instanceDetail, int index) {
 		this.applicationDetail = applicationDetail;
@@ -74,18 +76,19 @@ public class CloudFoundryAppInstanceStatus implements AppInstanceStatus {
 
 	@Override
 	public Map<String, String> getAttributes() {
-		Map<String, String> attributes = new LinkedHashMap<>();
 		if (instanceDetail != null) {
 			if (instanceDetail.getCpu() != null) {
-				attributes.put("cpu", String.format("%.1f%%", instanceDetail.getCpu() * 100d));
+				attributes.put("metrics.machine.cpu", String.format("%.1f%%", instanceDetail.getCpu() * 100d));
 			}
 			if (instanceDetail.getDiskQuota() != null && instanceDetail.getDiskUsage() != null) {
-				attributes.put("disk", String.format("%.1f%%", 100d * instanceDetail.getDiskUsage() / instanceDetail.getDiskQuota()));
+				attributes.put("metrics.machine.disk", String.format("%.1f%%", 100d * instanceDetail.getDiskUsage() / instanceDetail.getDiskQuota()));
 			}
 			if (instanceDetail.getMemoryQuota() != null && instanceDetail.getMemoryUsage() != null) {
-				attributes.put("memory", String.format("%.1f%%", 100d * instanceDetail.getMemoryUsage() / instanceDetail.getMemoryQuota()));
+				attributes.put("metrics.machine.memory", String.format("%.1f%%", 100d * instanceDetail.getMemoryUsage() / instanceDetail.getMemoryQuota()));
 			}
 		}
+		// TODO cf-java-client versions > 2.8 will have an index formally added ot InstanceDetail
+		attributes.put("guid", applicationDetail.getName() + ":" + index);
 		return attributes;
 	}
 


### PR DESCRIPTION
Fixes #177 

Tested this PR by running the metrics collector on PWS 

```
cf push mlp-metrics-collector -u none --no-start -p ./metrics-collector-rabbit-1.0.0.BUILD-SNAPSHOT.jar

cf bind-service mlp-metrics-collector rabbitmq

cf set-env mlp-metrics-collector SPRING_APPLICATION_JSON '{"spring.cloud.stream.bindings.input.destination":"metrics"}'
cf set-env mlp-metrics-collector SPRING_CLOUD_STREAM_DEFAULT_CONTENT_TYPE application/json
cf set-env mlp-metrics-collector SECURITY_BASIC_ENABLED false
cf set-env mlp-metrics-collector MANAGEMENT_SECURITY_ENABLED false

cf restage mlp-metrics-collector
```

and running the PCF SCDF server locally with this PR.  Also needed to configure `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_STATUS_TIMEOUT=60000` as the default value of 2000 ms was too low for me when running locally. 

```
dataflow:>app register --name time120RS --type source --uri maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.0.BUILD-SNAPSHOT
Successfully registered application 'source:time120RS'
dataflow:>app register --name log120RS --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.BUILD-SNAPSHOT
Successfully registered application 'sink:log120RS'
dataflow:>stream create --name foostream --definition "time120RS |log120RS"
Created new stream 'foostream'
dataflow:>stream deploy --name foostream --properties "deployer.*.count=1,app.*.security.basic.enabled=false,app.*.management.security.enabled=false,app.*.spring.cloud.stream.bindings.applicationMetrics.destination=metrics"
dataflow:>runtime apps
╔═════════════════════════════╤═══════════╤═════════════════════════════════════════════════════════════════════════════╗
║    App Id / Instance Id     │Unit Status│                        No. of Instances / Attributes                        ║
╠═════════════════════════════╪═══════════╪═════════════════════════════════════════════════════════════════════════════╣
║V2fI0gs-foostream-log120RS   │ deployed  │                                      1                                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                             │           │                                         guid = V2fI0gs-foostream-log120RS:0 ║
║                             │           │metrics.integration.channel.input.receiveRate = 1.00                         ║
║V2fI0gs-foostream-log120RS-0 │ deployed  │  metrics.integration.channel.output.sendRate = 0.00                         ║
║                             │           │                          metrics.machine.cpu = 0.3%                         ║
║                             │           │                         metrics.machine.disk = 14.9%                        ║
║                             │           │                       metrics.machine.memory = 46.5%                        ║
╟─────────────────────────────┼───────────┼─────────────────────────────────────────────────────────────────────────────╢
║V2fI0gs-foostream-time120RS  │ deployed  │                                      1                                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                             │           │                                         guid = V2fI0gs-foostream-time120RS:0║
║                             │           │metrics.integration.channel.input.receiveRate = 0.00                         ║
║V2fI0gs-foostream-time120RS-0│ deployed  │  metrics.integration.channel.output.sendRate = 1.00                         ║
║                             │           │                          metrics.machine.cpu = 0.4%                         ║
║                             │           │                         metrics.machine.disk = 15.0%                        ║
║                             │           │                       metrics.machine.memory = 45.4%                        ║
╚═════════════════════════════╧═══════════╧═════════════════════════════════════════════════════════════════════════════╝

```
