### PR TITLE
Push With Manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-deployer-spi.version>1.2.0.RELEASE</spring-cloud-deployer-spi.version>
-		<cloudfoundry-java-lib.version>2.11.0.RELEASE</cloudfoundry-java-lib.version>
+		<cloudfoundry-java-lib.version>2.14.0.RELEASE</cloudfoundry-java-lib.version>
 		<reactor-core.version>3.0.7.RELEASE</reactor-core.version>
-		<reactor-netty.version>0.6.3.RELEASE</reactor-netty.version>
+		<reactor-netty.version>0.6.4.RELEASE</reactor-netty.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
@@ -35,8 +35,7 @@ import org.springframework.cloud.deployer.spi.task.TaskStatus;
 
 /**
  * Abstract class to provide base functionality for launching Tasks on Cloud Foundry.
- * This class provides the base SPI for  {@link CloudFoundry2620AndEarlierTaskLauncher}
- * and {@link CloudFoundry2630AndLaterTaskLauncher}.
+ * This class provides the base SPI for the {@link CloudFoundry2630AndLaterTaskLauncher}.
  *
  * Does not override the default no-op implementation for {@link TaskLauncher#cleanup(String)}
  * and {@link TaskLauncher#destroy(String)}.

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -93,11 +93,9 @@ public class CloudFoundryDeployerAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(AppDeployer.class)
 	public AppDeployer appDeployer(CloudFoundryOperations operations,
-		CloudFoundryClient client,
 		AppNameGenerator applicationNameGenerator) {
 		return new CloudFoundryAppDeployer(
 			applicationNameGenerator,
-			client,
 			connectionConfiguration.appDeploymentProperties(),
 			operations,
 			runtimeEnvironmentInfo(AppDeployer.class, CloudFoundryAppDeployer.class)
@@ -113,7 +111,6 @@ public class CloudFoundryDeployerAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(TaskLauncher.class)
 	public TaskLauncher taskLauncher(CloudFoundryClient client,
-		CloudFoundryConnectionProperties connectionProperties,
 		CloudFoundryOperations operations,
 		Version version) {
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %-18thread %-33logger %msg%n</pattern>
+            <pattern>%date{HH:mm:ss.SSS} %-25thread %-37logger %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
A recent update to the Cloud Foundry Java Client added support for pushing with an application manifest.  This allows a simpler invocation of the `CloudFoundryOperations` when pushing removing the need to deal with environment variables, service bindings, and start as separate steps.  This change updates the code to take advantage of this new API.

