### PR TITLE
Increase default API timeout to 360s.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -100,9 +100,7 @@ public class CloudFoundryDeploymentProperties {
 	/**
 	 * Timeout for blocking API calls, in seconds.
 	 */
-	private long apiTimeout = 30L;
-
-
+	private long apiTimeout = 360L;
 
 	/**
 	 * Timeout for status API operations in milliseconds


### PR DESCRIPTION
This aligns with the value used in SCDF and is more practical for real world
task situations. Applies not only to running integration tests in the
absence of external (env var) customization, but also when the deployer is
embedded (eg Task Launcher).

Fixes https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/issues/189