### PR TITLE
Java Client 2.11.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-deployer-spi.version>1.2.0.RC2</spring-cloud-deployer-spi.version>
-		<cloudfoundry-java-lib.version>2.11.0.BUILD-SNAPSHOT</cloudfoundry-java-lib.version>
+		<cloudfoundry-java-lib.version>2.11.0.RELEASE</cloudfoundry-java-lib.version>
 		<reactor-core.version>3.0.7.RELEASE</reactor-core.version>
 		<reactor-netty.version>0.6.3.RELEASE</reactor-netty.version>
 	</properties>


### PR DESCRIPTION
This change upgrades the Java Client to [2.11.0.RELEASE](https://github.com/cloudfoundry/cf-java-client/releases/tag/v2.11.0.RELEASE).  This includes changes around both chunked transfer encoding and multipart uploads.