### PR TITLE
Add support for setting health check timeout

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
-import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.DOMAIN_PROPERTY;
-import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.HEALTHCHECK_ENDPOINT_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.HEALTHCHECK_HTTP_ENDPOINT_PROPERTY_KEY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.HEALTHCHECK_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.HEALTHCHECK_TIMEOUT_PROPERTY_KEY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.HOST_PROPERTY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.NO_ROUTE_PROPERTY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.ROUTE_PATH_PROPERTY;
@@ -286,9 +286,15 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			.orElse(this.deploymentProperties.getHealthCheck());
 	}
 
-	private String healthEndpoint(AppDeploymentRequest request) {
-		return Optional.ofNullable(request.getDeploymentProperties().get(HEALTHCHECK_ENDPOINT_PROPERTY_KEY))
+	private String healthCheckEndpoint(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(HEALTHCHECK_HTTP_ENDPOINT_PROPERTY_KEY))
 				.orElse(this.deploymentProperties.getHealthCheckHttpEndpoint());
+	}
+
+	private Integer healthCheckTimeout(AppDeploymentRequest request) {
+		String timeoutString = request.getDeploymentProperties()
+				.getOrDefault(HEALTHCHECK_TIMEOUT_PROPERTY_KEY, this.deploymentProperties.getHealthCheckTimeout());
+		return Integer.parseInt(timeoutString);
 	}
 
 	private String host(AppDeploymentRequest request) {
@@ -308,7 +314,8 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			.disk(diskQuota(request))
 			.environmentVariables(getEnvironmentVariables(deploymentId, request))
 			.healthCheckType(healthCheck(request))
-			.healthCheckHttpEndpoint(healthEndpoint(request))
+			.healthCheckHttpEndpoint(healthCheckEndpoint(request))
+			.timeout(healthCheckTimeout(request))
 			.instances(instances(request))
 			.memory(memory(request))
 			.name(deploymentId)

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -39,7 +39,9 @@ public class CloudFoundryDeploymentProperties {
 
 	public static final String HEALTHCHECK_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".health-check";
 
-	public static final String HEALTHCHECK_ENDPOINT_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".health-check-endpoint";
+	public static final String HEALTHCHECK_HTTP_ENDPOINT_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".health-check-http-endpoint";
+
+	public static final String HEALTHCHECK_TIMEOUT_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".health-check-timeout";
 
 	public static final String ROUTE_PATH_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".route-path";
 
@@ -95,6 +97,11 @@ public class CloudFoundryDeploymentProperties {
 	 * The path that the http health check will use, defaults to @{code /health}
 	 */
 	private String healthCheckHttpEndpoint = "/health";
+
+	/**
+	 * The timeout value for health checks in seconds.  Defaults to 120 seconds.
+	 */
+	private String healthCheckTimeout = "120";
 
 	/**
 	 * The number of instances to run.
@@ -229,6 +236,14 @@ public class CloudFoundryDeploymentProperties {
 
 	public void setHealthCheckHttpEndpoint(String healthCheckHttpEndpoint) {
 		this.healthCheckHttpEndpoint = healthCheckHttpEndpoint;
+	}
+
+	public String getHealthCheckTimeout() {
+		return healthCheckTimeout;
+	}
+
+	public void setHealthCheckTimeout(String healthCheckTimeout) {
+		this.healthCheckTimeout = healthCheckTimeout;
 	}
 
 	public String getDomain() {


### PR DESCRIPTION
* Rename property for heath check endpoint from
  `health-check-endpoint` to `health-check-http-endpoint` to be consistent
  with naming in CF manifest

Fixes #228