### PR TITLE
Add ability to configure multiple routes.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -24,13 +24,16 @@ import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDe
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.NO_ROUTE_PROPERTY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.ROUTE_PATH_PROPERTY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.ROUTE_PROPERTY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.ROUTES_PROPERTY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.USE_SPRING_APPLICATION_JSON_KEY;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -328,6 +331,12 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 		if (route(request) != null) {
 			manifest.route(Route.builder().route(route(request)).build());
 		}
+		if (! routes(request).isEmpty()){
+		    Set<Route> routes = routes(request).stream()
+                    .map(r -> Route.builder().route(r).build())
+                    .collect(Collectors.toSet());
+		    manifest.routes(routes);
+        }
 		if(getDockerImage(request) != null){
 			manifest.docker(Docker.builder().image(getDockerImage(request)).build());
 		}else {
@@ -380,6 +389,13 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 	private String route(AppDeploymentRequest request) {
 		return request.getDeploymentProperties().get(ROUTE_PROPERTY);
 	}
+
+    private Set<String> routes(AppDeploymentRequest request) {
+        Set<String> routes = new HashSet<>();
+        routes.addAll(this.deploymentProperties.getRoutes());
+        routes.addAll(StringUtils.commaDelimitedListToSet(request.getDeploymentProperties().get(ROUTES_PROPERTY)));
+        return routes;
+    }
 
 	private ApplicationHealthCheck toApplicationHealthCheck(String raw) {
 		try {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -46,6 +46,8 @@ public class CloudFoundryDeploymentProperties {
 
 	public static final String ROUTE_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".route";
 
+	public static final String ROUTES_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".routes";
+
 	public static final String NO_ROUTE_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".no-route";
 
 	public static final String HOST_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".host";
@@ -71,6 +73,12 @@ public class CloudFoundryDeploymentProperties {
 	 * The domain to use when mapping routes for applications.
 	 */
 	private String domain;
+
+	/**
+	 * The routes that the application should be bound to.
+	 * Mutually exclusive with host and domain.
+	 */
+	private Set<String> routes = new HashSet<>();
 
 	/**
 	 * The buildpack to use for deploying the application.
@@ -228,7 +236,6 @@ public class CloudFoundryDeploymentProperties {
 		this.healthCheck = healthCheck;
 	}
 
-
 	public String getHealthCheckHttpEndpoint() {
 		return healthCheckHttpEndpoint;
 	}
@@ -261,6 +268,14 @@ public class CloudFoundryDeploymentProperties {
 		this.host = host;
 	}
 
+	public Set<String> getRoutes() {
+		return routes;
+	}
+
+	public void setRoutes(Set<String> routes) {
+		this.routes = routes;
+	}
+
 	public Duration getStagingTimeout() {
 		return stagingTimeout;
 	}
@@ -276,6 +291,7 @@ public class CloudFoundryDeploymentProperties {
 	public void setStartupTimeout(Duration startupTimeout) {
 		this.startupTimeout = startupTimeout;
 	}
+
 	public long getStatusTimeout() {
 		return statusTimeout;
 	}

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -38,8 +38,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.compress.utils.Sets;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.applications.ApplicationDetail;
 import org.cloudfoundry.operations.applications.ApplicationHealthCheck;
@@ -434,6 +436,64 @@ public class CloudFoundryAppDeployerTests {
 
 		assertThat(deploymentId, equalTo("test-application-id"));
 	}
+
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void deployWithMultipleRoutes() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		given(this.applicationNameGenerator.generateAppName("test-application")).willReturn("test-application-id");
+
+		givenRequestGetApplication("test-application-id",
+				Mono.error(new IllegalArgumentException()),
+				Mono.just(ApplicationDetail.builder()
+						.diskQuota(0)
+						.id("test-application-id")
+						.instances(1)
+						.memoryLimit(0)
+						.name("test-application")
+						.requestedState("RUNNING")
+						.runningInstances(0)
+						.stack("test-stack")
+						.build()));
+
+		this.deploymentProperties.setBuildpack("test-buildpack");
+		this.deploymentProperties.setDisk("0");
+		this.deploymentProperties.setHealthCheck(ApplicationHealthCheck.NONE);
+		this.deploymentProperties.setRoutes(Sets.newHashSet("route1.test-domain", "route2.test-domain"));
+		this.deploymentProperties.setInstances(0);
+		this.deploymentProperties.setMemory("0");
+
+		givenRequestPushApplication(PushApplicationManifestRequest.builder()
+				.manifest(ApplicationManifest.builder()
+						.path(resource.getFile().toPath())
+						.buildpack("test-buildpack")
+						.disk(0)
+						.routes(Sets.newHashSet(
+								Route.builder().route("route1.test-domain").build(),
+								Route.builder().route("route2.test-domain").build()
+						))
+						.environmentVariables(defaultEnvironmentVariables())
+						.healthCheckType(ApplicationHealthCheck.NONE)
+						.instances(0)
+						.memory(0)
+						.name("test-application-id")
+						.service("test-service-2")
+						.service("test-service-1")
+						.build())
+				.stagingTimeout(this.deploymentProperties.getStagingTimeout())
+				.startupTimeout(this.deploymentProperties.getStartupTimeout())
+				.build(), Mono.empty());
+
+		String deploymentId = this.deployer.deploy(new AppDeploymentRequest(
+				new AppDefinition("test-application", Collections.emptyMap()),
+				resource,
+				Collections.emptyMap()));
+
+		assertThat(deploymentId, equalTo("test-application-id"));
+	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -496,6 +496,33 @@ public class CloudFoundryAppDeployerTests {
 
 
 	@SuppressWarnings("unchecked")
+	@Test(expected = IllegalStateException.class)
+	public void deployWithMultipleRoutesAndHostOrDomainMutuallyExclusive() throws IOException {
+		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+
+		given(this.applicationNameGenerator.generateAppName("test-application")).willReturn("test-application-id");
+
+		givenRequestGetApplication("test-application-id",
+				Mono.error(new IllegalArgumentException()),
+				Mono.just(ApplicationDetail.builder()
+						.id("test-application-id")
+						.name("test-application")
+						.build()));
+
+		this.deploymentProperties.setHost("route0");
+		this.deploymentProperties.setDomain("test-domain");
+		this.deploymentProperties.setRoutes(Sets.newHashSet("route1.test-domain", "route2.test-domain"));
+
+		this.deployer.deploy(new AppDeploymentRequest(
+				new AppDefinition("test-application", Collections.emptyMap()),
+				resource,
+				Collections.emptyMap()));
+
+		fail("routes and hosts cannot be set, expect cf java client to throw an exception");
+	}
+
+
+	@SuppressWarnings("unchecked")
 	@Test
 	public void deployWithGroup() throws IOException {
 		Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");


### PR DESCRIPTION
PCF manifests support mapping an application to multiple routes:
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#routes
```
---
  ...
  routes:
  - route: example.com
  - route: www.example.com/foo
  - route: tcp-example.com:1234
```
This PR is very early on and needs tests/formatting fixes, but sort of gets the point across.

Note that `domain(s)` and `host(s)` are deprecated, and it is not possible to use `routes` together with `domain(s)` and  `host(s)`, as [in the cf docs](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#route-attribute).

This restriction is enforced in the cf java client, so I'm not sure what sort of validation is required or appropriate for this project.

https://github.com/cloudfoundry/cf-java-client/blob/dc168fdbcbbb72798d78e555acb72fc6a37ba9c3/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/_ApplicationManifest.java#L37-L49


Any guidance on where an appropriate place to add some tests would be?