### PR TITLE
Add support for passing JAVA_OPTS option

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY;
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.JAVA_OPTS_PROPERTY_KEY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY;
 
 import java.io.IOException;
@@ -49,6 +50,7 @@ import org.springframework.util.StringUtils;
  * Base class dealing with configuration overrides on a per-deployment basis, as well as common code for apps and tasks.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 class AbstractCloudFoundryDeployer {
 
@@ -85,6 +87,11 @@ class AbstractCloudFoundryDeployer {
 	String buildpack(AppDeploymentRequest request) {
 		return Optional.ofNullable(request.getDeploymentProperties().get(BUILDPACK_PROPERTY_KEY))
 			.orElse(this.deploymentProperties.getBuildpack());
+	}
+
+	String javaOpts(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(JAVA_OPTS_PROPERTY_KEY))
+				.orElse(this.deploymentProperties.getJavaOpts());
 	}
 
 	Predicate<Throwable> isNotFoundError() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Eric Bottard
  * @author Greg Turnquist
  * @author Ben Hale
+ * @author Ilayaperumal Gopinathan
  */
 public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implements MultiStateAppDeployer {
 
@@ -254,8 +255,12 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 		Map<String, String> envVariables = new HashMap<>();
 		envVariables.putAll(getApplicationProperties(deploymentId, request));
 		envVariables.putAll(getCommandLineArguments(request));
+		String javaOpts = javaOpts(request);
+		if (StringUtils.hasText(javaOpts)) {
+			envVariables.put("JAVA_OPTS", javaOpts(request));
+		}
 		String group = request.getDeploymentProperties().get(AppDeployer.GROUP_PROPERTY_KEY);
-		if (group != null) {
+		if (StringUtils.hasText(group)) {
 			envVariables.put("SPRING_CLOUD_APPLICATION_GROUP", group);
 		}
 		envVariables.put("SPRING_CLOUD_APPLICATION_GUID", "${vcap.application.name}:${vcap.application.instance_index}");

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Value;
  *
  * @author Eric Bottard
  * @author Greg Turnquist
+ * @author Ilayaperumal Gopinathan
  */
 public class CloudFoundryDeploymentProperties {
 
@@ -55,6 +56,8 @@ public class CloudFoundryDeploymentProperties {
 	public static final String DOMAIN_PROPERTY = CLOUDFOUNDRY_PROPERTIES + ".domain";
 
 	public static final String BUILDPACK_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".buildpack";
+
+	public static final String JAVA_OPTS_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".javaOpts";
 
 	public static final String USE_SPRING_APPLICATION_JSON_KEY = CLOUDFOUNDRY_PROPERTIES + ".use-spring-application-json";
 
@@ -155,6 +158,8 @@ public class CloudFoundryDeploymentProperties {
 	 * Whether to also delete routes when un-deploying an application.
 	 */
 	private boolean deleteRoutes = true;
+
+	private String javaOpts;
 
 	public Set<String> getServices() {
 		return services;
@@ -306,5 +311,13 @@ public class CloudFoundryDeploymentProperties {
 
 	public void setDeleteRoutes(boolean deleteRoutes) {
 		this.deleteRoutes = deleteRoutes;
+	}
+
+	public String getJavaOpts() {
+		return javaOpts;
+	}
+
+	public void setJavaOpts(String javaOpts) {
+		this.javaOpts = javaOpts;
 	}
 }


### PR DESCRIPTION
 - Add `javaOpts` as the CloudFoundry Deployment properties
   - the same property can be set via Deployment Request as well
 - Set JAVA_OPTS environment variable if it is set

Resolves #242