### PR TITLE
Delete application resources after successful deploy

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
@@ -178,7 +178,7 @@ class AbstractCloudFoundryDeployer {
 
 	protected void deleteLocalApplicationResourceFile(AppDeploymentRequest appDeploymentRequest) {
 		try {
-			if (!appDeploymentRequest.getResource().getURI().toString().startsWith("docker:")) {
+			if (!appDeploymentRequest.getResource().getURI().getScheme().toLowerCase().startsWith("http")) {
 				File applicationFile = appDeploymentRequest.getResource().getFile();
 				boolean deleted = applicationFile.delete();
 				logger.debug((deleted) ? "Successfully deleted the application resource: "+ applicationFile.getCanonicalPath() :

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
@@ -20,6 +20,7 @@ import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDe
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.JAVA_OPTS_PROPERTY_KEY;
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -173,6 +174,21 @@ class AbstractCloudFoundryDeployer {
 				.andThen(retries -> Flux.from(retries).doOnComplete(() ->
 					logger.info("Successfully retried getStatus operation status [{}] for {}", id))))
 			.doOnError(e -> logger.error(String.format("Retry operation on getStatus failed for %s.  Max retry time %sms", id, statusTimeout)));
+	}
+
+	protected void deleteLocalApplicationResourceFile(AppDeploymentRequest appDeploymentRequest) {
+		try {
+			if (!appDeploymentRequest.getResource().getURI().toString().startsWith("docker:")) {
+				File applicationFile = appDeploymentRequest.getResource().getFile();
+				boolean deleted = applicationFile.delete();
+				logger.debug((deleted) ? "Successfully deleted the application resource: "+ applicationFile.getCanonicalPath() :
+						"Could not delete the application resource: "+ applicationFile.getCanonicalPath());
+			}
+		}
+		catch (IOException e) {
+			logger.warn("Exception deleting the application resource after successful CF push request."
+					+ " This could cause increase in disk space. The exception is: " + e.getMessage());
+		}
 	}
 
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
@@ -94,7 +94,10 @@ public class CloudFoundry2630AndLaterTaskLauncher extends AbstractCloudFoundryTa
 	public String launch(AppDeploymentRequest request) {
 		return getOrDeployApplication(request)
 			.flatMap(application -> launchTask(application, request))
-			.doOnSuccess(r -> logger.info("Task {} launch successful", request.getDefinition().getName()))
+			.doOnSuccess(r -> {
+				logger.info("Task {} launch successful", request.getDefinition().getName());
+				deleteLocalApplicationResourceFile(request);
+			})
 			.doOnError(logError(String.format("Task %s launch failed", request.getDefinition().getName())))
 			.block(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundry2630AndLaterTaskLauncher.java
@@ -96,9 +96,11 @@ public class CloudFoundry2630AndLaterTaskLauncher extends AbstractCloudFoundryTa
 			.flatMap(application -> launchTask(application, request))
 			.doOnSuccess(r -> {
 				logger.info("Task {} launch successful", request.getDefinition().getName());
-				deleteLocalApplicationResourceFile(request);
 			})
 			.doOnError(logError(String.format("Task %s launch failed", request.getDefinition().getName())))
+			.doOnSuccessOrError((r, e) -> {
+				deleteLocalApplicationResourceFile(request);
+			})
 			.block(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -108,7 +108,6 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			.timeout(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()))
 			.doOnSuccess(item -> {
 				logger.info("Successfully deployed {}", deploymentId);
-				deleteLocalApplicationResourceFile(request);
 			})
 			.doOnError(error -> {
 				if (isNotFoundError().test(error)) {
@@ -117,6 +116,9 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 				else {
 					logError(String.format("Failed to deploy %s", deploymentId)).accept(error);
 				}
+			})
+			.doOnSuccessOrError((r, e) -> {
+				deleteLocalApplicationResourceFile(request);
 			})
 			.subscribe();
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -108,6 +108,7 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			.timeout(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()))
 			.doOnSuccess(item -> {
 				logger.info("Successfully deployed {}", deploymentId);
+				deleteLocalApplicationResourceFile(request);
 			})
 			.doOnError(error -> {
 				if (isNotFoundError().test(error)) {


### PR DESCRIPTION
 - For stream/task applications, if the application resources use non-docker based schemes then delete the locally downloaded resource after successful deployment/launch.

Resolves #256