### PR TITLE
Add value hints for health-check property

### DIFF
--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,21 @@
+{
+  "hints": [
+    {
+      "name": "spring.cloud.deployer.cloudfoundry.health-check",
+      "values": [
+        {
+          "value": "NONE"
+        },
+        {
+          "value": "HTTP"
+        },
+        {
+          "value": "PROCESS"
+        },
+        {
+          "value": "PORT"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Add value hints for spring.cloud.deployer.cloudfoundry.health-check
  using additional-spring-configuration-metadata.json.
- This is a first change of this type which allows UI to catch up
  and use real values as type
  `org.cloudfoundry.operations.applications.ApplicationHealthCheck`
  is naturally unknown outside of java IDE's.
- Fixes #291

NOTE: to see a change in UI needs to be used with https://github.com/spring-cloud/spring-cloud-dataflow-ui/pull/1188