### PR TITLE
Implement getLog() for CF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.3.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud-deployer-spi.version>2.0.2.RELEASE</spring-cloud-deployer-spi.version>
+		<spring-cloud-deployer-spi.version>2.0.3.BUILD-SNAPSHOT</spring-cloud-deployer-spi.version>
 		<cloudfoundry-java-lib.version>3.15.0.RELEASE</cloudfoundry-java-lib.version>
 		<reactor-core.version>3.2.0.RELEASE</reactor-core.version>
 		<reactor-netty.version>0.7.12.RELEASE</reactor-netty.version>

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/UnsupportedVersionTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/UnsupportedVersionTaskLauncher.java
@@ -83,6 +83,11 @@ public class UnsupportedVersionTaskLauncher implements TaskLauncher {
 		throw failure();
 	}
 
+	@Override
+	public String getLog(String appName) {
+		throw failure();
+	}
+
 	private UnsupportedOperationException failure() {
 		return new UnsupportedOperationException("Cloud Foundry API version " + actualVersion + " is earlier than "
 			+ MINIMUM_SUPPORTED_VERSION + " and is incompatible with cf-java-client " +


### PR DESCRIPTION
 - for both the AppDeployer and TaskLauncher implementations
 - Use CF Java Client's interface to retrieve logs

Resolves #295