### PR TITLE
Add support for non-default CF identity providers.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,10 @@ SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SERVICES
 SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME
 SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD
 
+# the identity provider to be used when accessing the Cloud Foundry API (optional)
+# the passed string has to be a URL-Encoded JSON Object, containing the field origin with value as origin_key of an identity provider.
+SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_LOGIN_HINT
+
 # whether to allow self-signed certificates during SSL validation
 SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION
 ----

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
-import org.springframework.validation.annotation.Validated;
+import java.net.URL;
 
 import javax.validation.constraints.NotNull;
-import java.net.URL;
+
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Holds configuration properties for connecting to a Cloud Foundry runtime.

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
-import java.net.URL;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
-
-import org.springframework.validation.annotation.Validated;
+import java.net.URL;
 
 /**
  * Holds configuration properties for connecting to a Cloud Foundry runtime.
@@ -65,6 +64,12 @@ public class CloudFoundryConnectionProperties {
 	 */
 	@NotNull
 	private String password;
+
+	/**
+	 * Indicates the identity provider to be used when accessing the Cloud Foundry API.
+	 * The passed string has to be a URL-Encoded JSON Object, containing the field origin with value as origin_key of an identity provider.
+	 */
+	private String loginHint;
 
 	/**
 	 * Allow operation using self-signed certificates.
@@ -119,4 +124,11 @@ public class CloudFoundryConnectionProperties {
 		this.skipSslValidation = skipSslValidation;
 	}
 
+	public String getLoginHint() {
+		return loginHint;
+	}
+
+	public void setLoginHint(String loginHint) {
+		this.loginHint = loginHint;
+	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -16,10 +16,6 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
-import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
-
-import java.time.Duration;
-
 import com.github.zafarkhaja.semver.Version;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.info.GetInfoRequest;
@@ -32,7 +28,6 @@ import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -46,6 +41,10 @@ import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+
+import java.time.Duration;
+
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
 
 /**
  * Creates a {@link CloudFoundryAppDeployer}
@@ -192,6 +191,7 @@ public class CloudFoundryDeployerAutoConfiguration {
 			return PasswordGrantTokenProvider.builder()
 				.username(properties.getUsername())
 				.password(properties.getPassword())
+				.loginHint(properties.getLoginHint())
 				.build();
 		}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
+import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
+
+import java.time.Duration;
+
 import com.github.zafarkhaja.semver.Version;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.info.GetInfoRequest;
@@ -28,6 +32,7 @@ import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,10 +46,6 @@ import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-
-import java.time.Duration;
-
-import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
 
 /**
  * Creates a {@link CloudFoundryAppDeployer}

--- a/src/test/java/org/springframework/cloud/deployer/CloudFoundryTestSupport.java
+++ b/src/test/java/org/springframework/cloud/deployer/CloudFoundryTestSupport.java
@@ -84,6 +84,7 @@ public class CloudFoundryTestSupport extends AbstractExternalResourceTestSupport
 			return PasswordGrantTokenProvider.builder()
 					.username(properties.getUsername())
 					.password(properties.getPassword())
+					.loginHint(properties.getLoginHint())
 					.build();
 		}
 


### PR DESCRIPTION
Exposes a new config property named login hint, which allows supporting non-default IDPs (https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/issues/316).
The new property (loginHint) should include a URL-Encoded JSON Object, containing the field origin with value as origin_key of an identity provider (e.g. %7B%22origin%22%3A%22uaa%22%7D).

Resolves #316 