### PR TITLE
Implement AppDeployer#scale() operation

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
@@ -39,6 +39,7 @@ import org.cloudfoundry.util.DelayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppScaleRequest;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.util.ByteSizeUtils;
@@ -80,6 +81,22 @@ class AbstractCloudFoundryDeployer {
 		String withUnit = request.getDeploymentProperties()
 			.getOrDefault(AppDeployer.MEMORY_PROPERTY_KEY, this.deploymentProperties.getMemory());
 		return (int) ByteSizeUtils.parseToMebibytes(withUnit);
+	}
+
+	int memory(AppScaleRequest request) {
+		if (request.getProperties().isPresent() && request.getProperties().get() != null) {
+			return (int) ByteSizeUtils.parseToMebibytes((String)request.getProperties().get().getOrDefault(AppDeployer.MEMORY_PROPERTY_KEY,
+					this.deploymentProperties.getMemory()));
+		}
+		return (int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getMemory());
+	}
+
+	int diskQuota(AppScaleRequest request) {
+		if (request.getProperties().isPresent() && request.getProperties().get() != null) {
+			return (int) ByteSizeUtils.parseToMebibytes((String)request.getProperties().get().getOrDefault(AppDeployer.DISK_PROPERTY_KEY,
+					this.deploymentProperties.getDisk()));
+		}
+		return (int) ByteSizeUtils.parseToMebibytes(this.deploymentProperties.getDisk());
 	}
 
 	Set<String> servicesToBind(AppDeploymentRequest request) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -38,6 +38,7 @@ import org.cloudfoundry.operations.applications.InstanceDetail;
 import org.cloudfoundry.operations.applications.LogsRequest;
 import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
 import org.cloudfoundry.operations.applications.Route;
+import org.cloudfoundry.operations.applications.ScaleApplicationRequest;
 import org.cloudfoundry.operations.applications.StartApplicationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +47,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppScaleRequest;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.app.MultiStateAppDeployer;
@@ -74,8 +76,6 @@ import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDe
  * @author David Turanski
  */
 public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implements MultiStateAppDeployer {
-
-
 
 	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryAppDeployer.class);
 
@@ -206,6 +206,27 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			stringBuilder.append(logMessage.getMessage() + System.lineSeparator());
 		}
 		return stringBuilder.toString();
+	}
+
+	@Override
+	public void scale(AppScaleRequest appScaleRequest) {
+		logger.info("Scaling the application instance [{}] to {} number of instances.", appScaleRequest.getDeploymentId(),
+				appScaleRequest.getCount());
+		ScaleApplicationRequest scaleApplicationRequest = ScaleApplicationRequest.builder()
+				.name(appScaleRequest.getDeploymentId())
+				.instances(appScaleRequest.getCount())
+				.memoryLimit(memory(appScaleRequest))
+				.diskLimit(diskQuota(appScaleRequest))
+				.stagingTimeout(this.deploymentProperties.getStagingTimeout())
+				.startupTimeout(this.deploymentProperties.getStartupTimeout())
+				.build();
+		this.operations.applications().scale(scaleApplicationRequest)
+				.timeout(Duration.ofSeconds(this.deploymentProperties.getApiTimeout()))
+				.doOnSuccess(v -> logger.info("Scaled the application {} to {} number of instances.",
+						appScaleRequest.getDeploymentId(), appScaleRequest.getCount()))
+				.doOnError(e -> logger.error("Error: {} scaling the app instance {}", e.getMessage(),
+						appScaleRequest.getDeploymentId()))
+				.subscribe();
 	}
 
 	private Flux<LogMessage> getLogMessage(String deploymentId) {


### PR DESCRIPTION
 - Implement scale() operation by sending `ScaleApplicationRequest` via CF client
   - Set appropriate values including the deployment ID, instances, memory/disk quota along with the staging/startup timeout
 - Add test in DeployerTests

Resolves #318