### PR TITLE
Automatically configure environment for CfEnv

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,16 +95,9 @@ This is useful in cases in which the Cloud Foundry foundation is isolated from e
 == Set Additional Environment Variables
 
 By default, the deployer adds global and application configuration properties to a single `SPRING_APPLICATION_JSON` environment variable entry in the application manifest.
-You can configure additional environment variables in the manifest by setting `spring.cloud.deployer.cloudfoundry.env.<key>=<value>`.
-This is useful for setting https://github.com/cloudfoundry/java-buildpack[Java build pack configuration properties] in the application manifest.
+You can configure additional top-level environment variables in the manifest by setting `spring.cloud.deployer.cloudfoundry.env.<key>=<value>`.
+This is useful for adding https://github.com/cloudfoundry/java-buildpack[Java build pack configuration properties] to the application manifest since the Java build pack does not recognize `SPRING_APPLICATION_JSON`.
 
-=== Disable Spring Auto-reconfiguration
-A common use case is to disable auto-reconfiguration if your application handles configuration internally, as is the case if your application uses https://github.com/pivotal-cf/java-cfenv[java-cfenv] to
-bind to CF services. In this case, you would set:
-
-----
-spring.cloud.deployer.cloudfoundry.env.JBP_CONFIG_SPRING_AUTO_RECONFIGURATION='{enabled:false}',spring.cloud.deployer.cloudfoundry.env.SPRING_PROFILES_ACTIVE=cloud
-----
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-loader</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
@@ -31,13 +31,13 @@ import org.cloudfoundry.client.v3.tasks.TaskState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
-import reactor.util.function.Tuple2;
 
 /**
  * Abstract class to provide base functionality for launching Tasks on Cloud Foundry. This

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareAppDeploymentRequest.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareAppDeploymentRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+
+/**
+ * Copies an {@link AppDeploymentRequest} using a {@link CfEnvAwareResource}.
+ *
+ * @author David Turanski
+ * @since 2.4
+ */
+class CfEnvAwareAppDeploymentRequest extends AppDeploymentRequest {
+
+	static CfEnvAwareAppDeploymentRequest of(AppDeploymentRequest appDeploymentRequest) {
+		return new CfEnvAwareAppDeploymentRequest(appDeploymentRequest);
+	}
+
+	private CfEnvAwareAppDeploymentRequest(AppDeploymentRequest appDeploymentRequest) {
+		super(appDeploymentRequest.getDefinition(),
+				CfEnvAwareResource.of(appDeploymentRequest.getResource()),
+				appDeploymentRequest.getDeploymentProperties(),
+				appDeploymentRequest.getCommandlineArguments());
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
@@ -137,7 +137,7 @@ class CfEnvAwareResource implements Resource {
 						urls.add(a.getUrl());
 					}
 					catch (MalformedURLException e) {
-						e.printStackTrace();
+						logger.error("Unable to process nested archive " +  e.getMessage());
 					}
 				});
 				URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), null);

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.loader.archive.JarFileArchive;
+import org.springframework.core.io.Resource;
+
+/**
+ * A {@link Resource} implementation that delegates to a resource and keeps the state of a CfEnv dependency
+ * as an {@link Optional} which may be empty, true, or false.
+ *
+ * @author David Turanski
+ * @since 2.4
+ */
+class CfEnvAwareResource implements Resource {
+	private final Resource resource;
+
+	private final boolean hasCfEnv;
+
+	static CfEnvAwareResource of(Resource resource) {
+		return new CfEnvAwareResource(resource);
+	}
+	private CfEnvAwareResource(Resource resource) {
+		this.resource = resource;
+		this.hasCfEnv = CfEnvResolver.hasCfEnv(this);
+	}
+
+	@Override
+	public boolean exists() {
+		return resource.exists();
+	}
+
+	@Override
+	public URL getURL() throws IOException {
+		return resource.getURL();
+	}
+
+	@Override
+	public URI getURI() throws IOException {
+		return resource.getURI();
+	}
+
+	@Override
+	public File getFile() throws IOException {
+		return resource.getFile();
+	}
+
+	@Override
+	public long contentLength() throws IOException {
+		return resource.contentLength();
+	}
+
+	@Override
+	public long lastModified() throws IOException {
+		return resource.lastModified();
+	}
+
+	@Override
+	public Resource createRelative(String s) throws IOException {
+		return resource.createRelative(s);
+	}
+
+	@Override
+	public String getFilename() {
+		return resource.getFilename();
+	}
+
+	@Override
+	public String getDescription() {
+		return resource.getDescription();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return resource.getInputStream();
+	}
+
+	boolean hasCfEnv() {
+		return this.hasCfEnv;
+	}
+
+	/**
+	 * Inspect the {@link CfEnvAwareResource} to determine if it contains a dependency on <i>io.pivotal.cfenv.core.CfEnv</i>.
+	 * Cache the result in the resource.
+	 */
+	static class CfEnvResolver {
+
+		private static Log logger = LogFactory.getLog(CfEnvResolver.class);
+
+		private static final String CF_ENV = "io.pivotal.cfenv.core.CfEnv";
+
+		static boolean hasCfEnv(CfEnvAwareResource app
+		) {
+			try {
+				String scheme = app.getURI().getScheme().toLowerCase();
+				if (scheme.equals("docker")) {
+					return false;
+				}
+			}
+			catch (IOException e) {
+				throw new IllegalArgumentException(e.getMessage(), e);
+			}
+
+			try {
+				JarFileArchive archive = new JarFileArchive(app.getFile());
+				List<URL> urls = new ArrayList<>();
+				archive.getNestedArchives(entry -> entry.getName().endsWith(".jar")).forEach(a -> {
+					try {
+						urls.add(a.getUrl());
+					}
+					catch (MalformedURLException e) {
+						e.printStackTrace();
+					}
+				});
+				URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), null);
+				try {
+					Class.forName(CF_ENV, false, classLoader);
+					return true;
+				}
+				catch (ClassNotFoundException e) {
+					logger.debug(app.getFilename() + " does not contain " + CF_ENV);
+					return false;
+				}
+			}
+			catch (Exception e) {
+				logger.warn("Unable to determine dependencies for " + app.getFilename());
+			}
+			return false;
+		}
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurer.java
@@ -111,6 +111,7 @@ import org.springframework.util.StringUtils;
 			if (!Stream.of(current.split(",")).filter(s -> s.trim().equals(value)).findFirst().isPresent()) {
 				return current.join(",", current, value);
 			}
+			return current;
 		}
 		return value;
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides methods to configure environment, application properties, and command line args if the deployed artifact uses java-cfenv.
+ *
+ * @author David Turanski
+ * @since 2.4
+ */
+ class CfEnvConfigurer {
+ 	static final String SPRING_PROFILES_ACTIVE = "SPRING_PROFILES_ACTIVE";
+
+ 	static final String SPRING_PROFILES_ACTIVE_FQN = "spring.profiles.active";
+
+	static final String SPRING_PROFILES_ACTIVE_HYPHENATED = "spring-profiles-active";
+
+	static final String CLOUD_PROFILE_NAME = "cloud";
+
+	static final String JBP_CONFIG_SPRING_AUTO_RECONFIGURATION = "JBP_CONFIG_SPRING_AUTO_RECONFIGURATION";
+
+	static final String ENABLED_FALSE = "{ enabled: false }";
+
+	/**
+	 * Disable Java Buildpack Spring Auto-reconfiguration.
+	 *
+	 * @param environment a map containing environment variables
+	 * @return an copy of the map setting the environment variable needed to disable auto-reconfiguration
+	 */
+	 static Map<String, String> disableJavaBuildPackAutoReconfiguration(Map<String, String> environment) {
+		Map<String, String> updatedEnvironment = new HashMap<>(environment);
+		updatedEnvironment.putIfAbsent(JBP_CONFIG_SPRING_AUTO_RECONFIGURATION, ENABLED_FALSE);
+		return updatedEnvironment;
+	}
+
+	/**
+	 * Activate the <i>cloud</i> profile. Add to a key that binds to <i>spring.profiles.active</i> if one exists.
+	 * @param environment a map containing environment variables or application properties
+	 * @param keyToCreate create a new entry using a preferred key if none exists.
+	 * @return the updated map
+	 */
+	 static Map<String,String> activateCloudProfile(Map<String, String> environment, String keyToCreate) {
+
+		Map<String, String> updatedEnvironment = new HashMap<>(environment);
+
+		if (appendToExistingEntry(updatedEnvironment, SPRING_PROFILES_ACTIVE, CLOUD_PROFILE_NAME)) {
+				return updatedEnvironment;
+		}
+		else if (appendToExistingEntry(updatedEnvironment, SPRING_PROFILES_ACTIVE_FQN, CLOUD_PROFILE_NAME)) {
+				return updatedEnvironment;
+		}
+		else if (appendToExistingEntry(updatedEnvironment, SPRING_PROFILES_ACTIVE_HYPHENATED, CLOUD_PROFILE_NAME)) {
+			return updatedEnvironment;
+		}
+		// If Key provided, create new spring profiles active entry.
+		if (StringUtils.hasText(keyToCreate)) {
+			updatedEnvironment.put(keyToCreate, CLOUD_PROFILE_NAME);
+		}
+
+		return updatedEnvironment;
+	}
+
+	/**
+	 * Process a command line argument to append the <i>cloud</i> profile if it binds to
+	 * <i>spring.profiles.active</i>.
+	 *
+	 * @param arg the current value
+	 * @return the updated value
+	 */
+	 static String appendCloudProfileToSpringProfilesActiveArg(String arg)  {
+		  if ( (arg.contains(SPRING_PROFILES_ACTIVE_FQN) ||
+			arg.contains(SPRING_PROFILES_ACTIVE_HYPHENATED) ||
+			arg.contains(SPRING_PROFILES_ACTIVE) ) && arg.contains("=")) {
+		  	String[]tokens = arg.split("=");
+			arg = String.join("=", tokens[0], appendToValueIfPresent(tokens[1], CLOUD_PROFILE_NAME));
+		  }
+		return arg;
+	 }
+
+	private static boolean appendToExistingEntry(Map<String, String> environment, String key, String value) {
+		if (environment.containsKey(key)) {
+			String current = environment.get(key);
+			environment.put(key,appendToValueIfPresent(current, value));
+			return true;
+		}
+		return false;
+	}
+
+	private static String appendToValueIfPresent(String current, String value) {
+		if (StringUtils.hasText(current)) {
+			if (!Stream.of(current.split(",")).filter(s -> s.trim().equals(value)).findFirst().isPresent()) {
+				return current.join(",", current, value);
+			}
+		}
+		return value;
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -104,7 +104,8 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 	}
 
 	@Override
-	public String deploy(AppDeploymentRequest request) {
+	public String deploy(AppDeploymentRequest appDeploymentRequest) {
+		final AppDeploymentRequest request = CfEnvAwareAppDeploymentRequest.of(appDeploymentRequest);
 		logger.trace("Entered deploy: Deploying AppDeploymentRequest: AppDefinition = {}, Resource = {}, Deployment Properties = {}",
 			request.getDefinition(), request.getResource(), request.getDeploymentProperties());
 		String deploymentId = deploymentId(request);
@@ -511,6 +512,4 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 			.map(Boolean::valueOf)
 			.orElse(null);
 	}
-
-
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResourceTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResourceTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author David Turanski
+ */
+public class CfEnvAwareResourceTests {
+
+	@Test
+	public void testCfEnvResolverWithCfEnv() throws IOException {
+		CfEnvAwareResource resource = CfEnvAwareResource.of(new ClassPathResource("log-sink-rabbit-3.0.0.BUILD-SNAPSHOT.jar"));
+		assertThat(resource.hasCfEnv()).isTrue();
+	}
+
+	@Test
+	public void testCfEnvResolverWithNoCfEnv() throws IOException {
+		CfEnvAwareResource resource = CfEnvAwareResource.of(new ClassPathResource("batch-job-1.0.0.BUILD-SNAPSHOT.jar"));
+		assertThat(resource.hasCfEnv()).isFalse();
+	}
+
+	@Test
+	public void testDoesNothingWithDocker() throws IOException, URISyntaxException {
+		Resource docker = mock(Resource.class);
+		when(docker.getURI()).thenReturn(new URI("docker://fake/news"));
+		assertThat(CfEnvAwareResource.of(docker).hasCfEnv()).isFalse();
+	}
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurerTests.java
@@ -27,47 +27,61 @@ public class CfEnvConfigurerTests {
 
 	@Test
 	public void testCfEnvConfigurerActivateCloudProfile() {
-		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+		Map<String, String> env = CfEnvConfigurer.activateCloudProfile(
 				Collections.EMPTY_MAP, CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN);
-		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+		assertThat(env).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
 				CfEnvConfigurer.CLOUD_PROFILE_NAME);
-		assertThat(updatedEnv).doesNotContainKeys(
+		assertThat(env).doesNotContainKeys(
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
 	}
 
 	@Test
 	public void testCfEnvConfigurerDoNotActivateCloudProfileIfNoneExists() {
-		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+		Map<String, String> env = CfEnvConfigurer.activateCloudProfile(
 				Collections.EMPTY_MAP, null);
-		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+		assertThat(env).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
 	}
 
 	@Test
 	public void testCfEnvConfigurerActivateCloudProfileWithEmptyValue() {
-		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+		Map<String, String> env = CfEnvConfigurer.activateCloudProfile(
 				FluentMap.<String, String>builder()
 						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE, " ")
 						.build(),
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE);
-		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+		assertThat(env).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
 				CfEnvConfigurer.CLOUD_PROFILE_NAME);
-		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+		assertThat(env).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
 	}
 
 	@Test
 	public void testCfEnvConfigurerAppendToActiveProfiles() {
-		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+		Map<String, String> env = CfEnvConfigurer.activateCloudProfile(
 				FluentMap.<String, String>builder()
 						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,bar")
-						.build(),
-				CfEnvConfigurer.SPRING_PROFILES_ACTIVE);
-		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,bar,cloud");
-		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+						.build(), null);
+		assertThat(env).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,bar,cloud");
+		assertThat(env).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
 				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
+	}
+
+	@Test
+	public void testCfEnvConfigurerDoesNotAppendCloudProfileIfAlreadyThere() {
+		Map<String, String> env = CfEnvConfigurer.activateCloudProfile(
+				FluentMap.<String, String>builder()
+						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,cloud")
+						.build(), null);
+		assertThat(env).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,cloud");
+
+		env = CfEnvConfigurer.activateCloudProfile(
+				FluentMap.<String, String>builder()
+						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "cloud,foo,bar")
+						.build(), null);
+		assertThat(env).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "cloud,foo,bar");
 	}
 
 	@Test
@@ -76,8 +90,11 @@ public class CfEnvConfigurerTests {
 				.isEqualTo("--spring-profiles-active=foo,bar,cloud");
 		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--spring.profiles.active=foo"))
 				.isEqualTo("--spring.profiles.active=foo,cloud");
+		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--spring.profiles.active=foo,cloud"))
+				.isEqualTo("--spring.profiles.active=foo,cloud");
+		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--spring.profiles.active=cloud"))
+				.isEqualTo("--spring.profiles.active=cloud");
 		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--baz=foo"))
 				.isEqualTo("--baz=foo");
 	}
-
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvConfigurerTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.util.Collections;
+import java.util.Map;
+import org.cloudfoundry.util.FluentMap;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CfEnvConfigurerTests {
+
+	@Test
+	public void testCfEnvConfigurerActivateCloudProfile() {
+		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+				Collections.EMPTY_MAP, CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN);
+		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+				CfEnvConfigurer.CLOUD_PROFILE_NAME);
+		assertThat(updatedEnv).doesNotContainKeys(
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
+	}
+
+	@Test
+	public void testCfEnvConfigurerDoNotActivateCloudProfileIfNoneExists() {
+		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+				Collections.EMPTY_MAP, null);
+		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
+	}
+
+	@Test
+	public void testCfEnvConfigurerActivateCloudProfileWithEmptyValue() {
+		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+				FluentMap.<String, String>builder()
+						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE, " ")
+						.build(),
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE);
+		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+				CfEnvConfigurer.CLOUD_PROFILE_NAME);
+		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN,
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
+	}
+
+	@Test
+	public void testCfEnvConfigurerAppendToActiveProfiles() {
+		Map<String, String> updatedEnv = CfEnvConfigurer.activateCloudProfile(
+				FluentMap.<String, String>builder()
+						.entry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,bar")
+						.build(),
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE);
+		assertThat(updatedEnv).containsEntry(CfEnvConfigurer.SPRING_PROFILES_ACTIVE_FQN, "foo,bar,cloud");
+		assertThat(updatedEnv).doesNotContainKeys(CfEnvConfigurer.SPRING_PROFILES_ACTIVE,
+				CfEnvConfigurer.SPRING_PROFILES_ACTIVE_HYPHENATED);
+	}
+
+	@Test
+	public void testCloudProfileAppendedToCommandLineArgs() {
+		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--spring-profiles-active=foo,bar"))
+				.isEqualTo("--spring-profiles-active=foo,bar,cloud");
+		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--spring.profiles.active=foo"))
+				.isEqualTo("--spring.profiles.active=foo,cloud");
+		assertThat(CfEnvConfigurer.appendCloudProfileToSpringProfilesActiveArg("--baz=foo"))
+				.isEqualTo("--baz=foo");
+	}
+
+}


### PR DESCRIPTION
Resolves #344 

Updated PR since @ilayaperumalg first reviewed it.  

This adds `CfEnfAwareResource` and clones the immutable `AppDeploymentRequest` as `CfEnvAwareApplicationDeploymentRequest` to contain the CfEnvAwareResource.  The app deployer and task launcher do the conversion first in `deploy` and `launch` respectively.  

`CfEnvAwareResource` determines if it includes `CfEnv.class` at creation time and sets its `hasCfEnv` property.  This only applies to boot jars,  e.g. Docker images are not inspected as it would require a docker daemon to inspect the image.  
If CfEnv is present, the deployer will:

 * disable auto-reconfiguration in the Java build pack
 * activate the cloud profile if it is not already declared active in any external property source (environment variable, application properties, or command line args) 
* if any of these contains a property key that binds to `spring.profiles.active` and does not already include `cloud`, `cloud` will be appended.  
* if `spring.profiles.active` is not declared it will add it as an application property (in `SPRING_APPLICATION_JSON` by default). 

NOTE: This will be convenient for users of upcoming releases of supported stream-applications, since they all use `java-cfenv` and will fail on cloud foundry without this configuration.  At some future time the Java build pack may incorporate `java-cfenv` to make this obsolete.  CNB buildpacks will include similar features, although via an new service binding configuration standard that does not use `VCAP_SERVICES`. 







