### PR TITLE
Customise platform client id and secret

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,18 @@ public class CloudFoundryConnectionProperties {
 	private String password;
 
 	/**
+	 * ClientId to use with token providers, effectively defaults to "cf" in
+	 * cloudfroundry client.
+	 */
+	private String clientId;
+
+	/**
+	 * ClientSecret to use with token providers, effectively defaults to empty in
+	 * cloudfroundry client.
+	 */
+	private String clientSecret;
+
+	/**
 	 * Indicates the identity provider to be used when accessing the Cloud Foundry API.
 	 * The passed string has to be a URL-Encoded JSON Object, containing the field origin with value as origin_key of an identity provider.
 	 */
@@ -99,6 +111,22 @@ public class CloudFoundryConnectionProperties {
 
 	public void setUrl(URL url) {
 		this.url = url;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
 	}
 
 	public String getUsername() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
+import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,7 @@ import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES;
 
@@ -192,11 +194,17 @@ public class CloudFoundryDeployerAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public TokenProvider tokenProvider(CloudFoundryConnectionProperties properties) {
-			return PasswordGrantTokenProvider.builder()
-				.username(properties.getUsername())
-				.password(properties.getPassword())
-				.loginHint(properties.getLoginHint())
-				.build();
+			Builder tokenProviderBuilder = PasswordGrantTokenProvider.builder()
+					.username(properties.getUsername())
+					.password(properties.getPassword())
+					.loginHint(properties.getLoginHint());
+			if (StringUtils.hasText(properties.getClientId())) {
+				tokenProviderBuilder.clientId(properties.getClientId());
+			}
+			if (StringUtils.hasText(properties.getClientSecret())) {
+				tokenProviderBuilder.clientSecret(properties.getClientSecret());
+			}
+			return tokenProviderBuilder.build();
 		}
 
 		@Bean

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionPropertiesTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CloudFoundryConnectionPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	public void setAllProperties() {
+		this.contextRunner
+		.withInitializer(context -> {
+			Map<String, Object> map = new HashMap<>();
+			map.put("spring.cloud.deployer.cloudfoundry.org", "org");
+			map.put("spring.cloud.deployer.cloudfoundry.space", "space");
+			map.put("spring.cloud.deployer.cloudfoundry.url", "http://example.com");
+			map.put("spring.cloud.deployer.cloudfoundry.username", "username");
+			map.put("spring.cloud.deployer.cloudfoundry.password", "password");
+			map.put("spring.cloud.deployer.cloudfoundry.client-id", "id");
+			map.put("spring.cloud.deployer.cloudfoundry.client-secret", "secret");
+			map.put("spring.cloud.deployer.cloudfoundry.login-hint", "hint");
+			map.put("spring.cloud.deployer.cloudfoundry.skip-ssl-validation", "true");
+			context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+				StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				CloudFoundryConnectionProperties properties = context.getBean(CloudFoundryConnectionProperties.class);
+				assertThat(properties.getOrg()).isEqualTo("org");
+				assertThat(properties.getSpace()).isEqualTo("space");
+				assertThat(properties.getUrl().toString()).isEqualTo("http://example.com");
+				assertThat(properties.getUsername()).isEqualTo("username");
+				assertThat(properties.getPassword()).isEqualTo("password");
+				assertThat(properties.getClientId()).isEqualTo("id");
+				assertThat(properties.getClientSecret()).isEqualTo("secret");
+				assertThat(properties.getLoginHint()).isEqualTo("hint");
+				assertThat(properties.isSkipSslValidation()).isTrue();
+			});
+	}
+
+	@EnableConfigurationProperties
+	private static class Config1 {
+
+		@Bean
+		@ConfigurationProperties(prefix = CloudFoundryConnectionProperties.CLOUDFOUNDRY_PROPERTIES)
+		public TestCloudFoundryConnectionProperties testCloudFoundryConnectionProperties() {
+			return new TestCloudFoundryConnectionProperties();
+		}
+	}
+
+	private static class TestCloudFoundryConnectionProperties extends CloudFoundryConnectionProperties {
+		// not to get Configuration Processor @Bean Duplicate Prefix Definition error
+	}
+}


### PR DESCRIPTION
- New connection props client-id and client-sercet.
- If defined, pass those into PasswordGrantTokenProvider where client-id would
  effectively change its default `cf` value for id.
- Fixes #348