### PR TITLE
Recreate TokenProvider

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionProperties.java
@@ -89,6 +89,11 @@ public class CloudFoundryConnectionProperties {
 	 */
 	private boolean skipSslValidation = false;
 
+	/**
+	 * Optionally in seconds allows to set expire time when underlying token provider will get recreated.
+	 */
+	private Integer tokenProviderValidity;
+
 	public String getOrg() {
 		return org;
 	}
@@ -159,5 +164,13 @@ public class CloudFoundryConnectionProperties {
 
 	public void setLoginHint(String loginHint) {
 		this.loginHint = loginHint;
+	}
+
+	public Integer getTokenProviderValidity() {
+		return tokenProviderValidity;
+	}
+
+	public void setTokenProviderValidity(Integer tokenProviderValidity) {
+		this.tokenProviderValidity = tokenProviderValidity;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerAutoConfiguration.java
@@ -194,6 +194,10 @@ public class CloudFoundryDeployerAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public TokenProvider tokenProvider(CloudFoundryConnectionProperties properties) {
+			return new RecreatingTokenProvider(properties.getTokenProviderValidity(), () -> createTokenProvider(properties));
+		}
+
+		private TokenProvider createTokenProvider(CloudFoundryConnectionProperties properties) {
 			Builder tokenProviderBuilder = PasswordGrantTokenProvider.builder()
 					.username(properties.getUsername())
 					.password(properties.getPassword())

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/RecreatingTokenProvider.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/RecreatingTokenProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.util.Assert;
+
+/**
+ * {@link TokenProvider} which tracks when delegating provider is created
+ * allowing to re-create it based on token provider validity duration. This
+ * implementation mostly exists to overcome CFJC issue where it doesn't
+ * work anymore when refresh token gets invalid, thus we re-create to force
+ * CFJC to re-login.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class RecreatingTokenProvider implements TokenProvider {
+
+	private final static Logger log = LoggerFactory.getLogger(RecreatingTokenProvider.class);
+	private final Supplier<TokenProvider> supplier;
+	private TokenProvider tokenProvider;
+	private long tokenProviderValidity;
+	private long createdTime;
+
+	/**
+	 * Intantiate a new recreating token provider.
+	 *
+	 * If given token provider validity is higher than 0, {@link TokenProvider} is
+	 * re-created using a given supplier.
+	 *
+	 * @param tokenProviderValidity the validity time in millis
+	 * @param supplier the token provider supplier
+	 */
+	public RecreatingTokenProvider(Integer tokenProviderValidity, Supplier<TokenProvider> supplier) {
+		Assert.notNull(supplier, "TokenProvider supplier must be set");
+		this.tokenProviderValidity = tokenProviderValidity != null ? Duration.ofSeconds(tokenProviderValidity).toMillis() : 0;
+		this.supplier = supplier;
+		this.tokenProvider = createTokenProvider();
+	}
+
+	@Override
+	public Mono<String> getToken(ConnectionContext connectionContext) {
+		log.trace("getToken {} {}", connectionContext, this);
+		return getOrRecreateTokenProvider().getToken(connectionContext);
+	}
+
+	@Override
+	public void invalidate(ConnectionContext connectionContext) {
+		log.trace("invalidate {} {}", connectionContext, this);
+		this.tokenProvider.invalidate(connectionContext);
+	}
+
+	/**
+	 * Gets a token provider validity.
+	 *
+	 * @return token provider validity
+	 */
+	public long getTokenProviderValidity() {
+		return tokenProviderValidity;
+	}
+
+	/**
+	 * Sets a token provider validity.
+	 *
+	 * @param tokenProviderValidity the validity time in millis
+	 */
+	public void setTokenProviderValidity(long tokenProviderValidity) {
+		this.tokenProviderValidity = tokenProviderValidity;
+	}
+
+	private TokenProvider createTokenProvider() {
+		createdTime = System.currentTimeMillis();
+		return this.supplier.get();
+	}
+
+	private synchronized TokenProvider getOrRecreateTokenProvider() {
+		if (tokenProviderValidity > 0 && System.currentTimeMillis() > (createdTime + tokenProviderValidity)) {
+			this.tokenProvider = createTokenProvider();
+			log.debug("recreated token provider {}", this.tokenProvider);
+		}
+		return this.tokenProvider;
+	}
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryConnectionPropertiesTests.java
@@ -47,6 +47,7 @@ public class CloudFoundryConnectionPropertiesTests {
 			map.put("spring.cloud.deployer.cloudfoundry.client-secret", "secret");
 			map.put("spring.cloud.deployer.cloudfoundry.login-hint", "hint");
 			map.put("spring.cloud.deployer.cloudfoundry.skip-ssl-validation", "true");
+			map.put("spring.cloud.deployer.cloudfoundry.token-provider-validity", "123");
 			context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
 				StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
 			})
@@ -62,6 +63,7 @@ public class CloudFoundryConnectionPropertiesTests {
 				assertThat(properties.getClientSecret()).isEqualTo("secret");
 				assertThat(properties.getLoginHint()).isEqualTo("hint");
 				assertThat(properties.isSkipSslValidation()).isTrue();
+				assertThat(properties.getTokenProviderValidity()).isEqualTo(123);
 			});
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/RecreatingTokenProviderTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/RecreatingTokenProviderTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.util.function.Supplier;
+
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class RecreatingTokenProviderTests {
+
+	@Test
+	public void testZero() {
+		ConnectionContext connectionContext = mock(ConnectionContext.class);
+		TestSupplier supplier = new TestSupplier();
+		RecreatingTokenProvider rProvider = new RecreatingTokenProvider(0, supplier);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+	}
+
+	@Test
+	public void testNull() {
+		ConnectionContext connectionContext = mock(ConnectionContext.class);
+		TestSupplier supplier = new TestSupplier();
+		RecreatingTokenProvider rProvider = new RecreatingTokenProvider(null, supplier);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+	}
+
+	@Test
+	public void testNegative() throws Exception {
+		ConnectionContext connectionContext = mock(ConnectionContext.class);
+		TestSupplier supplier = new TestSupplier();
+		RecreatingTokenProvider rProvider = new RecreatingTokenProvider(-1, supplier);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+		Thread.sleep(1100);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+	}
+
+	@Test
+	public void testOneSecond() throws Exception {
+		ConnectionContext connectionContext = mock(ConnectionContext.class);
+		TestSupplier supplier = new TestSupplier();
+		RecreatingTokenProvider rProvider = new RecreatingTokenProvider(1, supplier);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(1);
+		Thread.sleep(1100);
+		rProvider.getToken(connectionContext);
+		assertThat(supplier.supplied).isEqualTo(2);
+	}
+
+	private static class TestSupplier implements Supplier<TokenProvider> {
+		int supplied = 0;
+
+		@Override
+		public TokenProvider get() {
+			supplied++;
+			return new TokenProvider(){
+
+				@Override
+				public Mono<String> getToken(ConnectionContext connectionContext) {
+					return Mono.just("");
+				}
+			};
+		}
+	}
+}


### PR DESCRIPTION
- New connection prop tokenProviderValidity in seconds.
- Adding RecreatingTokenProvider which takes validity time and supplier
  to create token. What essentially happens is that when TokenProvider gets old
  enough, it gets re-created and thus forces new login.
- Fixes #350