### PR TITLE
Support multiple buildpacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-deployer.version>2.5.0-SNAPSHOT</spring-cloud-deployer.version>
-		<cloudfoundry-java-lib.version>4.8.0.RELEASE</cloudfoundry-java-lib.version>
+		<cloudfoundry-java-lib.version>4.9.0.BUILD-SNAPSHOT</cloudfoundry-java-lib.version>
 		<pivotal-cf-client-reactor.version>2.1.0.RELEASE</pivotal-cf-client-reactor.version>
 	</properties>
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryDeployer.java
@@ -159,11 +159,14 @@ class AbstractCloudFoundryDeployer {
 		String buidpackValue = request.getDeploymentProperties().get(BUILDPACK_PROPERTY_KEY);
 		if (buidpacksValue != null) {
 			return StringUtils.commaDelimitedListToSet(buidpacksValue);
-		} else if (buidpackValue != null) {
+		}
+		else if (buidpackValue != null) {
 			return new HashSet<>(Arrays.asList(buidpackValue));
-		} else if (!ObjectUtils.isEmpty((this.deploymentProperties.getBuildpacks()))) {
+		}
+		else if (!ObjectUtils.isEmpty((this.deploymentProperties.getBuildpacks()))) {
 			return this.deploymentProperties.getBuildpacks();
-		} else {
+		}
+		else {
 			return new HashSet<>(Arrays.asList(this.deploymentProperties.getBuildpack()));
 		}
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -383,7 +383,7 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 					+ ". This may take some time if the image must be downloaded from a remote container registry.");
 			manifest.docker(Docker.builder().image(getDockerImage(request)).build());
 		} else {
-			manifest.buildpack(buildpack(request));
+			manifest.buildpacks(buildpacks(request));
 		}
 
 		if (!includesServiceParameters(request)) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,11 +62,15 @@ public class CloudFoundryDeploymentProperties {
 
 	public static final String BUILDPACK_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".buildpack";
 
+	public static final String BUILDPACKS_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".buildpacks";
+
 	public static final String JAVA_OPTS_PROPERTY_KEY = CLOUDFOUNDRY_PROPERTIES + ".javaOpts";
 
 	public static final String USE_SPRING_APPLICATION_JSON_KEY = CLOUDFOUNDRY_PROPERTIES + ".use-spring-application-json";
 
 	public static final String ENV_KEY = CLOUDFOUNDRY_PROPERTIES + ".env";
+
+	private static final String DEFAULT_BUILDPACK = "https://github.com/cloudfoundry/java-buildpack.git#v4.29.1";
 
 	/**
 	 * The names of services to bind to all applications deployed as a module.
@@ -93,7 +97,13 @@ public class CloudFoundryDeploymentProperties {
 	/**
 	 * The buildpack to use for deploying the application.
 	 */
-	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git#v4.29.1";
+	@Deprecated
+	private String buildpack = DEFAULT_BUILDPACK;
+
+	/**
+	 * The buildpacks to use for deploying the application.
+	 */
+	private Set<String> buildpacks = new HashSet<>();
 
 	/**
 	 * The amount of memory to allocate, if not overridden per-app. Default unit is mebibytes, 'M' and 'G" suffixes supported.
@@ -197,12 +207,22 @@ public class CloudFoundryDeploymentProperties {
 		this.services = services;
 	}
 
+	@Deprecated
 	public String getBuildpack() {
 		return buildpack;
 	}
 
+	@Deprecated
 	public void setBuildpack(String buildpack) {
 		this.buildpack = buildpack;
+	}
+
+	public Set<String> getBuildpacks() {
+		return buildpacks;
+	}
+
+	public void setBuildpacks(Set<String> buildpacks) {
+		this.buildpacks = buildpacks;
 	}
 
 	public String getMemory() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ public class CloudFoundryTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 			.manifest(ApplicationManifest.builder()
 				.path(getApplication(request))
 				.docker(Docker.builder().image(getDockerImage(request)).build())
-				.buildpack(buildpack(request))
+				.buildpacks(buildpacks(request))
 				.command("echo '*** First run of container to allow droplet creation.***' && sleep 300")
 				.disk(diskQuota(request))
 				.environmentVariables(getEnvironmentVariables(name, request))

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeployerTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloudFoundryDeployerTests {
+
+	@Mock(answer = Answers.RETURNS_SMART_NULLS)
+	private RuntimeEnvironmentInfo runtimeEnvironmentInfo;
+
+	private Resource resource = new FileSystemResource("src/test/resources/demo-0.0.1-SNAPSHOT.jar");
+	private AppDefinition definition = new AppDefinition("test-application", Collections.emptyMap());
+
+	@Test
+	public void testBuildpacksDefault() {
+		CloudFoundryDeploymentProperties props = new CloudFoundryDeploymentProperties();
+		TestCloudFoundryDeployer deployer = new TestCloudFoundryDeployer(props, runtimeEnvironmentInfo);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		Set<String> buildpacks = deployer.buildpacks(request);
+		assertThat(buildpacks).hasSize(1);
+	}
+
+	@Test
+	public void testBuildpacksSingleMultiLogic() {
+		CloudFoundryDeploymentProperties props = new CloudFoundryDeploymentProperties();
+		props.setBuildpack("buildpack1");
+		TestCloudFoundryDeployer deployer = new TestCloudFoundryDeployer(props, runtimeEnvironmentInfo);
+		Map<String, String> deploymentProperties = new HashMap<>();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties, null);
+
+
+		Set<String> buildpacks = deployer.buildpacks(request);
+		assertThat(buildpacks).hasSize(1);
+		assertThat(buildpacks).contains("buildpack1");
+
+		props.setBuildpacks(new HashSet<>(Arrays.asList("buildpack2", "buildpack3")));
+		buildpacks = deployer.buildpacks(request);
+		assertThat(buildpacks).hasSize(2);
+		assertThat(buildpacks).contains("buildpack2", "buildpack3");
+
+		deploymentProperties.put(CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY, "buildpack4");
+		buildpacks = deployer.buildpacks(request);
+		assertThat(buildpacks).hasSize(1);
+		assertThat(buildpacks).contains("buildpack4");
+
+		deploymentProperties.put(CloudFoundryDeploymentProperties.BUILDPACKS_PROPERTY_KEY, "buildpack5,buildpack6");
+		buildpacks = deployer.buildpacks(request);
+		assertThat(buildpacks).hasSize(2);
+		assertThat(buildpacks).contains("buildpack5", "buildpack6");
+	}
+
+	private static class TestCloudFoundryDeployer extends AbstractCloudFoundryDeployer {
+
+		TestCloudFoundryDeployer(CloudFoundryDeploymentProperties deploymentProperties,
+				RuntimeEnvironmentInfo runtimeEnvironmentInfo) {
+			super(deploymentProperties, runtimeEnvironmentInfo);
+		}
+	}
+}


### PR DESCRIPTION
- Switch to using cf-java-client snapshots as
  new feature is there.
- Deprecate old buildpack setting and favour buildpacks
  if set and fallback to buildpack until deprecation
  is removed in future.
- Fixes #327