### PR TITLE
Deprecates Scheduler Property

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,6 +211,38 @@ public class CloudFoundryDeploymentProperties {
 
 	private Optional<Map<String, String>> env = Optional.empty();
 
+	/**
+	 * Top level prefix for Cloud Foundry related configuration properties.
+	 */
+	public static final String CLOUDFOUNDRY_PROPERTIES = "spring.cloud.scheduler.cloudfoundry";
+
+	/**
+	 * Location of the PCF scheduler REST API enpoint ot use.
+	 */
+	private String schedulerUrl;
+
+	/**
+	 * The number of retries allowed when scheduling a task if an {@link javax.net.ssl.SSLException} is thrown.
+	 */
+	private int scheduleSSLRetryCount = 5;
+
+	/**
+	 * The number of seconds to wait for a unSchedule to complete.
+	 */
+	private int unScheduleTimeoutInSeconds = 30;
+
+	/**
+	 * The number of seconds to wait for a schedule to complete.
+	 * This excludes the time it takes to stage the application on Cloud Foundry.
+	 */
+	private int scheduleTimeoutInSeconds = 30;
+
+	/**
+	 * The number of seconds to wait for a list of schedules to be returned.
+	 */
+	private int listTimeoutInSeconds = 60;
+
+
 	public Set<String> getServices() {
 		return services;
 	}
@@ -415,5 +447,45 @@ public class CloudFoundryDeploymentProperties {
 					return this.env;
 				}
 		).orElse(this.env = Optional.of(Collections.unmodifiableMap(env)));
+	}
+
+	public String getSchedulerUrl() {
+		return schedulerUrl;
+	}
+
+	public void setSchedulerUrl(String schedulerUrl) {
+		this.schedulerUrl = schedulerUrl;
+	}
+
+	public int getScheduleSSLRetryCount() {
+		return scheduleSSLRetryCount;
+	}
+
+	public void setScheduleSSLRetryCount(int scheduleSSLRetryCount) {
+		this.scheduleSSLRetryCount = scheduleSSLRetryCount;
+	}
+
+	public int getUnScheduleTimeoutInSeconds() {
+		return unScheduleTimeoutInSeconds;
+	}
+
+	public void setUnScheduleTimeoutInSeconds(int unScheduleTimeoutInSeconds) {
+		this.unScheduleTimeoutInSeconds = unScheduleTimeoutInSeconds;
+	}
+
+	public int getScheduleTimeoutInSeconds() {
+		return scheduleTimeoutInSeconds;
+	}
+
+	public void setScheduleTimeoutInSeconds(int scheduleTimeoutInSeconds) {
+		this.scheduleTimeoutInSeconds = scheduleTimeoutInSeconds;
+	}
+
+	public int getListTimeoutInSeconds() {
+		return listTimeoutInSeconds;
+	}
+
+	public void setListTimeoutInSeconds(int listTimeoutInSeconds) {
+		this.listTimeoutInSeconds = listTimeoutInSeconds;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/cloudfoundry/CloudFoundrySchedulerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/cloudfoundry/CloudFoundrySchedulerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @ConfigurationProperties(prefix = CloudFoundrySchedulerProperties.CLOUDFOUNDRY_PROPERTIES)
+@Deprecated
 public class CloudFoundrySchedulerProperties {
 
 	/**

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/cloudfoundry/SpringCloudSchedulerIntegrationIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/cloudfoundry/SpringCloudSchedulerIntegrationIT.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.spi.scheduler.cloudfoundry;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +89,10 @@ public class SpringCloudSchedulerIntegrationIT extends AbstractSchedulerIntegrat
 
 	@Override
 	protected Map<String, String> getDeploymentProperties() {
-		return Collections.singletonMap(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, deployerProps);
+		Map<String, String> deploymentProperties = new HashMap<>();
+		deploymentProperties.put(CloudFoundryDeploymentProperties.SERVICES_PROPERTY_KEY, deployerProps);
+		deploymentProperties.put(CloudFoundryAppScheduler.CRON_EXPRESSION_KEY, "57 13 ? * *");
+		return deploymentProperties;
 	}
 
 	@Override
@@ -129,11 +133,11 @@ public class SpringCloudSchedulerIntegrationIT extends AbstractSchedulerIntegrat
 		@ConditionalOnMissingBean
 		public ReactorSchedulerClient reactorSchedulerClient(ConnectionContext context,
 				TokenProvider passwordGrantTokenProvider,
-				CloudFoundrySchedulerProperties properties) {
+				CloudFoundryDeploymentProperties taskDeploymentProperties) {
 			return ReactorSchedulerClient.builder()
 					.connectionContext(context)
 					.tokenProvider(passwordGrantTokenProvider)
-					.root(Mono.just(properties.getSchedulerUrl()))
+					.root(Mono.just(taskDeploymentProperties.getSchedulerUrl()))
 					.build();
 		}
 
@@ -143,16 +147,11 @@ public class SpringCloudSchedulerIntegrationIT extends AbstractSchedulerIntegrat
 				CloudFoundryOperations operations,
 				CloudFoundryConnectionProperties properties,
 				TaskLauncher taskLauncher,
-				CloudFoundrySchedulerProperties schedulerProperties) {
+				CloudFoundryDeploymentProperties taskDeploymentProperties) {
 			return new CloudFoundryAppScheduler(client, operations, properties,
 					(CloudFoundryTaskLauncher) taskLauncher,
-					schedulerProperties);
+					taskDeploymentProperties);
 		}
 
-		@Bean
-		@ConditionalOnMissingBean
-		public CloudFoundrySchedulerProperties cloudFoundrySchedulerProperties() {
-			return new CloudFoundrySchedulerProperties();
-		}
 	}
 }


### PR DESCRIPTION
Scheduler properties should be retrieved from the deployment properties:
Child of https://github.com/spring-cloud/spring-cloud-dataflow/issues/4262
resolves #377