### PR TITLE
Add disk quota configuration when launching task

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
@@ -229,6 +229,7 @@ public class CloudFoundryTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 		return requestCreateTask(application.getId(),
 				getCommand(application, request),
 				memory(request),
+				diskQuota(request),
 				request.getDefinition().getName())
 			.map(CreateTaskResponse::getId);
 	}
@@ -257,12 +258,13 @@ public class CloudFoundryTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 			.build());
 	}
 
-	private Mono<CreateTaskResponse> requestCreateTask(String applicationId, String command, int memory, String name) {
+	private Mono<CreateTaskResponse> requestCreateTask(String applicationId, String command, int memory, int disk, String name) {
 		return this.client.tasks()
 			.create(CreateTaskRequest.builder()
 				.applicationId(applicationId)
 				.command(command)
 				.memoryInMb(memory)
+				.diskInMb(disk)
 				.name(name)
 				.build());
 	}

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncherTests.java
@@ -90,6 +90,7 @@ import static org.mockito.Mockito.mock;
  * @author Ben Hale
  * @author Glenn Renfro
  * @author David Turanski
+ * @author David Bernard
  */
 public class CloudFoundryTaskLauncherTests {
 	private final static int TASK_EXECUTION_COUNT = 10;
@@ -360,6 +361,7 @@ public class CloudFoundryTaskLauncherTests {
 		givenRequestCreateTask("test-application-id",
 				"test-command",
 				this.deploymentProperties.getMemory(),
+				this.deploymentProperties.getDisk(),
 				"test-application",
 				Mono.error(new UnsupportedOperationException()));
 
@@ -521,16 +523,18 @@ public class CloudFoundryTaskLauncherTests {
 	}
 
 	private void givenRequestCreateTask(String applicationId,
-			String command,
-			String memory,
-			String name,
-			Mono<CreateTaskResponse> response) {
+										String command,
+										String memory,
+										String disk,
+										String name,
+										Mono<CreateTaskResponse> response) {
 
 		given(this.client.tasks()
 			.create(CreateTaskRequest.builder()
 				.applicationId(applicationId)
 				.command(command)
 				.memoryInMb((int) ByteSizeUtils.parseToMebibytes(memory))
+					.diskInMb((int) ByteSizeUtils.parseToMebibytes(disk))
 				.name(name)
 				.build()))
 			.willReturn(response);
@@ -608,7 +612,8 @@ public class CloudFoundryTaskLauncherTests {
 			givenRequestCreateTask("test-application-id",
 						"test-command",
 						this.deploymentProperties.getMemory(),
-						"test-application",
+					this.deploymentProperties.getDisk(),
+					"test-application",
 						Mono.just(CreateTaskResponse.builder()
 					.id("test-task-id")
 					.memoryInMb(1024)
@@ -664,7 +669,8 @@ public class CloudFoundryTaskLauncherTests {
 		givenRequestCreateTask("test-application-id",
 					"test-command",
 					this.deploymentProperties.getMemory(),
-					"test-application",
+				this.deploymentProperties.getDisk(),
+				"test-application",
 					Mono.just(CreateTaskResponse.builder()
 				.id("test-task-id")
 				.memoryInMb(1024)
@@ -816,7 +822,8 @@ public class CloudFoundryTaskLauncherTests {
 		givenRequestCreateTask("test-application-id",
 					"test-command",
 					this.deploymentProperties.getMemory(),
-					"test-application",
+				this.deploymentProperties.getDisk(),
+				"test-application",
 					Mono.just(CreateTaskResponse.builder()
 				.id("test-task-id")
 				.memoryInMb(1024)
@@ -873,7 +880,8 @@ public class CloudFoundryTaskLauncherTests {
 		givenRequestCreateTask("test-application-id",
 					"test-command",
 					this.deploymentProperties.getMemory(),
-					"test-application",
+				this.deploymentProperties.getDisk(),
+				"test-application",
 					Mono.just(CreateTaskResponse.builder()
 				.id("test-task-id")
 				.memoryInMb(1024)


### PR DESCRIPTION
Currently task launcher takes into account memory configuration but not  disk configuration (like option -k of `cf run-task`).

It appears that disk quota given when application is "pushed" is not applied when the task is "run", so it is necessary to pass the disk parameter on task launching too.