### PR TITLE
Restore unique 'guid' values for each app instance (include index)

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppInstanceStatus.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppInstanceStatus.java
@@ -96,8 +96,7 @@ public class CloudFoundryAppInstanceStatus implements AppInstanceStatus {
 			}
 		}
 		// TODO cf-java-client versions > 2.8 will have an index formally added ot InstanceDetail
-		attributes.put("guid", applicationDetail.getId());
-		attributes.put("index", String.valueOf(index));
+		attributes.put("guid", applicationDetail.getName() + ":" + index);
 		return attributes;
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.utils.Sets;
-import org.assertj.core.data.MapEntry;
 import org.cloudfoundry.client.v2.ClientV2Exception;
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.applications.ApplicationDetail;
@@ -968,8 +967,7 @@ public class CloudFoundryAppDeployerTests {
 		assertThat(status.getInstances().get("test-application-0").toString())
 				.isEqualTo("CloudFoundryAppInstanceStatus[test-application-0 : deployed]");
 		assertThat(status.getInstances().get("test-application-0").getAttributes())
-				.containsExactly(MapEntry.entry("guid", "test-application-id"),
-						MapEntry.entry("index", "0"));
+				.isEqualTo(Collections.singletonMap("guid", "test-application:0"));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
The guid-only value will be exposed as "cf-guid" in this [upcoming PR](https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/pull/385/files#diff-5357d11483b96e0b8419d35037f94ec0370327aebe194f2bca0b808e7cce43d8R120) for actuator access.

Fixes https://github.com/spring-cloud/spring-cloud-dataflow-acceptance-tests/issues/353

cc: @dturanski 