### PR TITLE
Fix cfenv detection

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,6 +143,10 @@ class CfEnvAwareResource implements Resource {
 				URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), null);
 				try {
 					Class.forName(CF_ENV, false, classLoader);
+					return true;
+				}
+				catch (UnsupportedClassVersionError err) {
+					// class found but can't load it i.e. because it's newer class version
 					return true;
 				}
 				catch (ClassNotFoundException e) {

--- a/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResourceTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/CfEnvAwareResourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,14 @@ import static org.mockito.Mockito.when;
  * @author David Turanski
  */
 public class CfEnvAwareResourceTests {
+
+	@Test
+	public void testCfEnvResolverWithCfEnvJava17() throws IOException {
+		// this task app is compiled from a spring-cloud-task sample using jdk17
+		// and cfenv added to build
+		CfEnvAwareResource resource = CfEnvAwareResource.of(new ClassPathResource("timestamp-task-3.1.2-SNAPSHOT.jar"));
+		assertThat(resource.hasCfEnv()).isTrue();
+	}
 
 	@Test
 	public void testCfEnvResolverWithCfEnv() throws IOException {


### PR DESCRIPTION
Doing extra catch so that we don't fail with UnsupportedClassVersionError which happens if class file is found and loaded with older jdk than cfend is compiled. In this case we assue cfenv is present.

We're testing this with spring-cloud-task sample where cfenv is added via build.